### PR TITLE
feat(action): invokable ArchAction with __invoke and ActionInvokeMethodRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `arch-app-services` will be documented in this file.
 ## [Unreleased] - 2026-02-14 (PR #67)
 
 
+- ⚠️ **Breaking**: `ArchAction` implementations use `__invoke()` only (no `execute()`); PHPStan `ActionInvokeMethodRule` replaces `ActionExecuteMethodRule`
 - 🔧 **Changed**: update
 - 🔧 **Changed**: update dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ The package includes custom PHPStan rules at max level:
 3. **OnlyModelManagersCanPersistDataRule** - Only ModelManager/ModelService can persist data
 4. **NoLaravelHelpersForActionsRule** - Actions must use constructor injection, not `app()`, `resolve()`, `make()`
 5. **ServiceNamingConventionRule** - Services extending `BaseModelService` must end with `ModelService`
-6. **ActionExecuteMethodRule** - Actions must have proper execute/handle methods
+6. **ActionInvokeMethodRule** - Actions must expose only `__invoke()` as a public method (besides constructor)
 
 These rules maintain clean architecture boundaries.
 
@@ -201,7 +201,7 @@ final readonly class CreateUser implements ArchAction
         private UserModelService $userModelService,
     ) {}
 
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         $this->validate($data, [...]);
         $transformed = $this->build($data, [

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ final readonly class BulkImportUsers
      *     ignored: int
      * }
      */
-    public function execute(array $userData): array
+    public function __invoke(array $userData): array
     {
         if ($userData === []) {
             return [
@@ -379,7 +379,7 @@ final readonly class CreateUser
      * @param array<string, mixed> $data
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         // Validate input data
         $this->validate($data, [
@@ -397,7 +397,7 @@ final readonly class CreateUser
         $user = $this->userModelService->create($normalizedData);
         
         // Send verification email
-        $this->verifyUserAction->handle($user);
+        ($this->verifyUserAction)($user);
         
         return $user;
     }
@@ -568,14 +568,14 @@ final class UserController extends Controller
 {
     public function store(Request $request, CreateUser $createUser)
     {
-        $user = $createUser->execute($request->validated());
+        $user = ($createUser)($request->validated());
         
         return response()->json($user, 201);
     }
     
     public function show(Request $request, GetUser $getUser)
     {
-        $user = $getUser->handle($request->only(['email', 'name']));
+        $user = ($getUser)($request->only(['email', 'name']));
         
         return response()->json($user);
     }
@@ -583,7 +583,7 @@ final class UserController extends Controller
     public function updateName(Request $request, UpdateUserName $updateUserName)
     {
         $user = User::findOrFail($request->user_id);
-        $updateUserName->handle($request->name, $user);
+        ($updateUserName)($request->name, $user);
         
         return response()->json(['message' => 'Name updated successfully']);
     }
@@ -687,7 +687,7 @@ final readonly class CreateUser
 {
     use DataBuilder;
     
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         $dataNormalized = $this->build($data, [
             'email' => LowercaseEmailPipe::class,
@@ -734,7 +734,7 @@ final readonly class CreateUser
 {
     use DataValidator;
     
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         $this->validate($data, [
             'email' => 'required|email|unique:users',
@@ -770,7 +770,7 @@ final readonly class ProcessOrderAction
 {
     use ActionLogger;
     
-    public function execute(array $orderData): Order
+    public function __invoke(array $orderData): Order
     {
         $startTime = microtime(true);
         
@@ -935,7 +935,7 @@ These rules enforce clean architecture by ensuring:
 // ❌ Violation: Direct query in Action
 final readonly class GetUsers implements ArchAction
 {
-    public function execute(): Collection
+    public function __invoke(): Collection
     {
         return User::where('active', true)->get(); // PHPStan error!
     }
@@ -946,7 +946,7 @@ final readonly class GetUsers implements ArchAction
 {
     public function __construct(private UserModelService $service) {}
     
-    public function execute(): Collection
+    public function __invoke(): Collection
     {
         return $this->service->findByParams(['active' => true]);
     }

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -49,7 +49,7 @@ final readonly class CreateUserAction implements ArchAction
     {
     }
 
-    public function execute(): void
+    public function __invoke(): void
     {
         // TODO: Implement action logic
     }

--- a/docs/phpstan-rules.md
+++ b/docs/phpstan-rules.md
@@ -68,7 +68,7 @@ This ensures:
 ```php
 final readonly class CreateUser implements ArchAction
 {
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         // ❌ Violation: Direct save() call in Action
         $user = new User($data);
@@ -88,7 +88,7 @@ final readonly class CreateUser implements ArchAction
         private UserModelService $userModelService
     ) {}
     
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         // ✅ Correct: Data persistence through ModelManager
         // Service delegates to ModelManager internally
@@ -147,7 +147,7 @@ User::verified()->first();
 ```php
 final readonly class GetAllUsers implements ArchAction
 {
-    public function execute(): Collection
+    public function __invoke(): Collection
     {
         // ✅ Simple get() without conditions is allowed
         return User::get();
@@ -158,7 +158,7 @@ final readonly class GetAllUsers implements ArchAction
 ```php
 final readonly class CountAllUsers implements ArchAction
 {
-    public function execute(): int
+    public function __invoke(): int
     {
         // ✅ Simple count() without conditions is allowed
         return User::count();
@@ -169,7 +169,7 @@ final readonly class CountAllUsers implements ArchAction
 ```php
 final readonly class GetUserById implements ArchAction
 {
-    public function execute(int $id): ?User
+    public function __invoke(int $id): ?User
     {
         // ✅ Simple find() is allowed
         return User::find($id);
@@ -186,7 +186,7 @@ final readonly class GetActiveUsers implements ArchAction
         private UserModelService $userModelService
     ) {}
     
-    public function execute(): Collection
+    public function __invoke(): Collection
     {
         // ✅ Correct: Data retrieval with conditions through Repository
         // Service delegates to Repository internally
@@ -202,7 +202,7 @@ final readonly class CountVerifiedUsers implements ArchAction
         private UserModelService $userModelService
     ) {}
     
-    public function execute(): int
+    public function __invoke(): int
     {
         // ✅ Correct: Aggregates with conditions through Repository
         // Service delegates to Repository internally
@@ -283,7 +283,7 @@ final readonly class UserModelService extends BaseModelService
 ```php
 final readonly class ProcessUser implements ArchAction
 {
-    public function execute(User $user): void
+    public function __invoke(User $user): void
     {
         // ❌ Violation: Using app() helper with class constant
         $action = app(GetUser::class);
@@ -310,10 +310,10 @@ final readonly class ProcessUser implements ArchAction
         private GetUser $getUserAction
     ) {}
     
-    public function execute(User $user): void
+    public function __invoke(User $user): void
     {
         // ✅ Correct: Action injected via constructor
-        $user = $this->getUserAction->handle(['id' => $user->id]);
+        $user = ($this->getUserAction)(['id' => $user->id]);
     }
 }
 ```
@@ -351,27 +351,27 @@ final readonly class UserModelService extends BaseModelService
 
 **Note:** This rule only applies to classes that extend `BaseModelService`. The base class itself (`BaseModelService`) is excluded from this check.
 
-### 6. ActionExecuteMethodRule
+### 6. ActionInvokeMethodRule
 
-**Purpose:** Guarantees that every Action class exposes a single public entrypoint named `execute()`.
+**Purpose:** Guarantees that every Action class is invokable: it exposes exactly one public instance method, `__invoke()`, and no other public methods (the constructor is ignored).
 
-**Rationale:** Actions should provide one orchestration method. Additional public methods make the orchestration unclear and encourage bypassing the intended flow.
+**Rationale:** Actions should provide a single callable entry point. Extra public methods make orchestration unclear and encourage bypassing the intended flow.
 
 **Violations detected:**
-- Missing the public `execute()` method
-- Having any other public method (e.g., `handle()`, `process()`, helper methods)
+- Missing the public `__invoke()` method
+- Having any other public method (e.g., `execute()`, `handle()`, `process()`, helper methods)
 
 **Example violation:**
 
 ```php
 final readonly class ProcessUser implements ArchAction
 {
-    public function execute(User $user): void
+    public function __invoke(User $user): void
     {
         // ...
     }
 
-    public function handle(User $user): void
+    public function notify(User $user): void
     {
         // ❌ Extra public method
     }
@@ -383,9 +383,9 @@ final readonly class ProcessUser implements ArchAction
 ```php
 final readonly class ProcessUser implements ArchAction
 {
-    public function execute(User $user): void
+    public function __invoke(User $user): void
     {
-        // ✅ Single public entrypoint
+        // ✅ Single public entrypoint (invokable action)
     }
 }
 ```
@@ -493,7 +493,7 @@ services:
         tags:
             - phpstan.rules.rule
     -
-        class: Pekral\Arch\PHPStan\Rules\ActionExecuteMethodRule
+        class: Pekral\Arch\PHPStan\Rules\ActionInvokeMethodRule
         tags:
             - phpstan.rules.rule
     -

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -47,7 +47,7 @@ final readonly class CreateUser
 {
     use DataValidator;
     
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         $this->validate($data, [
             'email' => 'required|email|unique:users',
@@ -116,7 +116,7 @@ final readonly class CreateUser
      * @param array<string, mixed> $data
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         // Validate input data
         $this->validate($data, [
@@ -139,7 +139,7 @@ final readonly class CreateUser
 
 ```php
 // In action class
-public function execute(array $data): User
+public function __invoke(array $data): User
 {
     $this->validate($data, [
         'email' => ['required', 'email', 'unique:users'],
@@ -158,7 +158,7 @@ public function execute(array $data): User
 ### Conditional Validation
 
 ```php
-public function execute(array $data): User
+public function __invoke(array $data): User
 {
     $rules = [
         'email' => 'sometimes|email|unique:users',
@@ -176,7 +176,7 @@ public function execute(array $data): User
 ### Validation Messages in Different Languages
 
 ```php
-public function execute(array $data): User
+public function __invoke(array $data): User
 {
     $messages = [
         'email.required' => __('validation.required', ['attribute' => 'email']),
@@ -491,7 +491,7 @@ final readonly class CreateUserWithDTO
     ) {
     }
 
-    public function execute(CreateUserDTO $dto): User
+    public function __invoke(CreateUserDTO $dto): User
     {
         return $this->userModelService->create($dto->toArray());
     }
@@ -501,7 +501,7 @@ final readonly class CreateUserWithDTO
 public function store(Request $request, CreateUserWithDTO $action)
 {
     $dto = CreateUserDTO::validateAndCreate($request->all());
-    $user = $action->execute($dto);
+    $user = ($action)($dto);
     
     return response()->json($user, 201);
 }

--- a/examples/Actions/User/BulkDeleteUsersByParams.php
+++ b/examples/Actions/User/BulkDeleteUsersByParams.php
@@ -17,7 +17,7 @@ final readonly class BulkDeleteUsersByParams implements ArchAction
     /**
      * @param array<string, mixed> $parameters
      */
-    public function execute(array $parameters): void
+    public function __invoke(array $parameters): void
     {
         $this->userModelService->bulkDeleteByParams($parameters);
     }

--- a/examples/Actions/User/BulkImportUsers.php
+++ b/examples/Actions/User/BulkImportUsers.php
@@ -20,13 +20,24 @@ final readonly class BulkImportUsers implements ArchAction
 
     /**
      * @param array<int, array<string, mixed>> $userData
+     * @return array<int, array<string, mixed>>
+     */
+    private function prepareUserData(array $userData): array
+    {
+        $now = now();
+
+        return array_map(static fn (array $data): array => [...$data, 'created_at' => $now, 'updated_at' => $now], $userData);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $userData
      * @return array{
      *     total_processed: int,
      *     created: int,
      *     ignored: int
      * }
      */
-    public function execute(array $userData): array
+    public function __invoke(array $userData): array
     {
         if ($userData === []) {
             return [
@@ -55,17 +66,6 @@ final readonly class BulkImportUsers implements ArchAction
             'ignored' => $ignoredCount,
             'total_processed' => count($preparedData),
         ];
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $userData
-     * @return array<int, array<string, mixed>>
-     */
-    private function prepareUserData(array $userData): array
-    {
-        $now = now();
-
-        return array_map(static fn (array $data): array => [...$data, 'created_at' => $now, 'updated_at' => $now], $userData);
     }
 
 }

--- a/examples/Actions/User/BulkOperationsDemo.php
+++ b/examples/Actions/User/BulkOperationsDemo.php
@@ -26,7 +26,7 @@ final readonly class BulkOperationsDemo implements ArchAction
      *     final_user_count: int
      * }
      */
-    public function execute(): array
+    public function __invoke(): array
     {
         // Demo 1: Bulk create new users
         $newUsers = [

--- a/examples/Actions/User/CountVerifiedUsers.php
+++ b/examples/Actions/User/CountVerifiedUsers.php
@@ -14,7 +14,7 @@ final readonly class CountVerifiedUsers implements ArchAction
     {
     }
 
-    public function handle(): int
+    public function __invoke(): int
     {
         /** @var array<int, array<int, mixed>> $params */
         $params = [

--- a/examples/Actions/User/CountVerifiedUsersCached.php
+++ b/examples/Actions/User/CountVerifiedUsersCached.php
@@ -17,7 +17,7 @@ final readonly class CountVerifiedUsersCached implements ArchAction
     {
     }
 
-    public function handle(): int
+    public function __invoke(): int
     {
         /** @var array<int, array<int, mixed>> $params */
         $params = [

--- a/examples/Actions/User/CreateUser.php
+++ b/examples/Actions/User/CreateUser.php
@@ -26,7 +26,7 @@ final readonly class CreateUser implements ArchAction
      * @param array<string, mixed> $data
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function execute(array $data): User
+    public function __invoke(array $data): User
     {
         $this->validate($data, [
             'email' => 'required|email',
@@ -41,7 +41,7 @@ final readonly class CreateUser implements ArchAction
         );
         $model = $this->userModelService->create($dataNormalized);
 
-        $this->verifyUserAction->handle($model);
+        ($this->verifyUserAction)($model);
 
         return $model;
     }

--- a/examples/Actions/User/CreateUserWithDTO.php
+++ b/examples/Actions/User/CreateUserWithDTO.php
@@ -21,7 +21,7 @@ final readonly class CreateUserWithDTO implements ArchAction
     {
     }
 
-    public function execute(CreateUserDTO $dto): User
+    public function __invoke(CreateUserDTO $dto): User
     {
         $dataNormalized = $this->build(
             $dto->toArray(),
@@ -32,7 +32,7 @@ final readonly class CreateUserWithDTO implements ArchAction
         );
         $model = $this->userModelService->create($dataNormalized);
 
-        $this->verifyUserAction->handle($model);
+        ($this->verifyUserAction)($model);
 
         return $model;
     }

--- a/examples/Actions/User/DeleteUser.php
+++ b/examples/Actions/User/DeleteUser.php
@@ -15,7 +15,7 @@ final readonly class DeleteUser implements ArchAction
     {
     }
 
-    public function handle(int|User $user): void
+    public function __invoke(int|User $user): void
     {
         if ($user instanceof User) {
             $this->userModelService->deleteModel($user);

--- a/examples/Actions/User/DeleteUserByModelManager.php
+++ b/examples/Actions/User/DeleteUserByModelManager.php
@@ -15,7 +15,7 @@ final readonly class DeleteUserByModelManager implements ArchAction
     {
     }
 
-    public function handle(User $user): bool
+    public function __invoke(User $user): bool
     {
         return $this->userModelManager->delete($user);
     }

--- a/examples/Actions/User/GetOrCreateUser.php
+++ b/examples/Actions/User/GetOrCreateUser.php
@@ -27,7 +27,7 @@ final readonly class GetOrCreateUser implements ArchAction
      * @param array<string, mixed> $values Values to use when creating
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function execute(array $attributes, array $values = []): User
+    public function __invoke(array $attributes, array $values = []): User
     {
         $mergedData = [...$attributes, ...$values];
         

--- a/examples/Actions/User/GetUser.php
+++ b/examples/Actions/User/GetUser.php
@@ -18,7 +18,7 @@ final readonly class GetUser implements ArchAction
     /**
      * @param array<string, mixed> $filters
      */
-    public function handle(array $filters): User
+    public function __invoke(array $filters): User
     {
         return $this->userModelService->getOneByParams($filters);
     }

--- a/examples/Actions/User/GetUserCached.php
+++ b/examples/Actions/User/GetUserCached.php
@@ -20,7 +20,7 @@ final readonly class GetUserCached implements ArchAction
     /**
      * @param array<string, mixed> $filters
      */
-    public function handle(array $filters): User
+    public function __invoke(array $filters): User
     {
         $repository = $this->userModelService->getRepository();
         $cacheWrapper = $repository->cache();

--- a/examples/Actions/User/GetUsers.php
+++ b/examples/Actions/User/GetUsers.php
@@ -19,7 +19,7 @@ final readonly class GetUsers implements ArchAction
      * @param array<string, mixed> $filters
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, \Pekral\Arch\Tests\Models\User>
      */
-    public function handle(array $filters = []): LengthAwarePaginator
+    public function __invoke(array $filters = []): LengthAwarePaginator
     {
         /** @var \Illuminate\Pagination\LengthAwarePaginator<int, \Pekral\Arch\Tests\Models\User> $paginator */
         $paginator = $this->userModelService->paginateByParams($filters);

--- a/examples/Actions/User/GetUsersCached.php
+++ b/examples/Actions/User/GetUsersCached.php
@@ -19,7 +19,7 @@ final readonly class GetUsersCached implements ArchAction
      * @param array<string, mixed> $filters
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, \Pekral\Arch\Tests\Models\User>
      */
-    public function handle(array $filters = []): LengthAwarePaginator
+    public function __invoke(array $filters = []): LengthAwarePaginator
     {
         /** @var \Illuminate\Pagination\LengthAwarePaginator<int, \Pekral\Arch\Tests\Models\User> $paginator */
         $paginator = $this->userModelService->getRepository()->cache()->paginateByParams($filters);

--- a/examples/Actions/User/ImportUsers.php
+++ b/examples/Actions/User/ImportUsers.php
@@ -19,7 +19,7 @@ final readonly class ImportUsers implements ArchAction
      * @template TValue
      * @param array<int, array<TKey, TValue>> $data
      */
-    public function handle(array $data): int
+    public function __invoke(array $data): int
     {
         return $this->userModelService->bulkCreate($data);
     }

--- a/examples/Actions/User/RefreshUsers.php
+++ b/examples/Actions/User/RefreshUsers.php
@@ -19,7 +19,7 @@ final readonly class RefreshUsers implements ArchAction
      * @template TValue
      * @param array<int, array<TKey, TValue>> $data
      */
-    public function handle(array $data): int
+    public function __invoke(array $data): int
     {
         return $this->userModelService->bulkUpdate($data);
     }

--- a/examples/Actions/User/SearchUser.php
+++ b/examples/Actions/User/SearchUser.php
@@ -18,7 +18,7 @@ final readonly class SearchUser implements ArchAction
     /**
      * @param array<string, mixed> $filters
      */
-    public function handle(array $filters): ?User
+    public function __invoke(array $filters): ?User
     {
         return $this->userModelService->findOneByParams($filters);
     }

--- a/examples/Actions/User/SearchUserCached.php
+++ b/examples/Actions/User/SearchUserCached.php
@@ -18,7 +18,7 @@ final readonly class SearchUserCached implements ArchAction
     /**
      * @param array<string, mixed> $filters
      */
-    public function handle(array $filters): ?User
+    public function __invoke(array $filters): ?User
     {
         $repository = $this->userModelService->getRepository();
         $cacheWrapper = $repository->cache();

--- a/examples/Actions/User/SendWelcomeEmailWithLogging.php
+++ b/examples/Actions/User/SendWelcomeEmailWithLogging.php
@@ -10,19 +10,19 @@ use Pekral\Arch\Tests\Models\User;
 final class SendWelcomeEmailWithLogging implements ArchAction
 {
 
-    /**
-     * @param array<string, mixed> $context
-     */
-    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
-    public function execute(User $user, array $context = []): void
-    {
-        $this->sendEmail();
-    }
-
     private function sendEmail(): void
     {
         // Email sending logic would be here
         // For example: Mail::to($user->email)->send(new WelcomeEmail($user));
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function __invoke(User $user, array $context = []): void
+    {
+        $this->sendEmail();
     }
 
 }

--- a/examples/Actions/User/UpdateOrCreateUser.php
+++ b/examples/Actions/User/UpdateOrCreateUser.php
@@ -27,7 +27,7 @@ final readonly class UpdateOrCreateUser implements ArchAction
      * @param array<string, mixed> $values Values to update/create with
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function execute(array $attributes, array $values = []): User
+    public function __invoke(array $attributes, array $values = []): User
     {
         $mergedData = [...$attributes, ...$values];
         

--- a/examples/Actions/User/UpdateUser.php
+++ b/examples/Actions/User/UpdateUser.php
@@ -26,7 +26,7 @@ final readonly class UpdateUser implements ArchAction
      * @param array<string, mixed> $data
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function execute(User $model, array $data): User
+    public function __invoke(User $model, array $data): User
     {
         $this->validate($data, [
             'email' => 'required|email',

--- a/examples/Actions/User/UpdateUserName.php
+++ b/examples/Actions/User/UpdateUserName.php
@@ -19,7 +19,7 @@ final readonly class UpdateUserName implements ArchAction
     {
     }
 
-    public function handle(string $name, User $user): void
+    public function __invoke(string $name, User $user): void
     {
         $data = $this->build(['name' => $name], [UcFirstNamePipe::class]);
         $this->userModelService->updateModel($user, $data);

--- a/examples/Actions/User/UpdateUserWithDTO.php
+++ b/examples/Actions/User/UpdateUserWithDTO.php
@@ -21,7 +21,7 @@ final readonly class UpdateUserWithDTO implements ArchAction
     {
     }
 
-    public function execute(User $model, UpdateUserDTO $dto): User
+    public function __invoke(User $model, UpdateUserDTO $dto): User
     {
         $dataNormalized = $this->build(
             $dto->toArray(),

--- a/examples/Actions/User/VerifyUserAction.php
+++ b/examples/Actions/User/VerifyUserAction.php
@@ -12,7 +12,7 @@ use Pekral\Arch\Tests\Models\User;
 final class VerifyUserAction implements ArchAction
 {
 
-    public function handle(User $user): void
+    public function __invoke(User $user): void
     {
         if ($user->email_verified_at === null) {
             Notification::send($user, new VerifyEmail());

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -40,7 +40,7 @@ services:
         tags:
             - phpstan.rules.rule
     -
-        class: Pekral\Arch\PHPStan\Rules\ActionExecuteMethodRule
+        class: Pekral\Arch\PHPStan\Rules\ActionInvokeMethodRule
         tags:
             - phpstan.rules.rule
     -

--- a/phpstan/Rules/ActionInvokeMethodRule.php
+++ b/phpstan/Rules/ActionInvokeMethodRule.php
@@ -15,12 +15,12 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Class_>
  */
-final class ActionExecuteMethodRule implements Rule
+final class ActionInvokeMethodRule implements Rule
 {
 
     private const string ARCH_ACTION_INTERFACE = 'Pekral\Arch\Action\ArchAction';
 
-    private const string EXECUTE_METHOD = 'execute';
+    private const string INVOKE_METHOD = '__invoke';
 
     public function getNodeType(): string
     {
@@ -96,14 +96,14 @@ final class ActionExecuteMethodRule implements Rule
         $publicMethodNames = $this->getPublicMethodNames($classNode);
 
         if ($publicMethodNames === []) {
-            return [$this->missingExecuteError($className)];
+            return [$this->missingInvokeError($className)];
         }
 
         if (count($publicMethodNames) !== 1) {
             return [$this->multiplePublicMethodsError($className, $publicMethodNames)];
         }
 
-        if ($publicMethodNames[0] !== self::EXECUTE_METHOD) {
+        if ($publicMethodNames[0] !== self::INVOKE_METHOD) {
             return [$this->invalidMethodNameError($className, $publicMethodNames[0])];
         }
 
@@ -115,10 +115,14 @@ final class ActionExecuteMethodRule implements Rule
         return RuleErrorBuilder::message($message)->build();
     }
 
-    private function missingExecuteError(string $className): RuleError
+    private function missingInvokeError(string $className): RuleError
     {
         return $this->createError(
-            sprintf('Action class "%s" must declare a public "%s()" method.', $className, self::EXECUTE_METHOD),
+            sprintf(
+                'Action class "%s" must declare a public "%s()" method and no other public methods.',
+                $className,
+                self::INVOKE_METHOD,
+            ),
         );
     }
 
@@ -129,9 +133,9 @@ final class ActionExecuteMethodRule implements Rule
     {
         return $this->createError(
             sprintf(
-                'Action class "%s" must expose only the public "%s()" method, but found: %s.',
+                'Action class "%s" must not declare public methods other than "%s()", but found: %s.',
                 $className,
-                self::EXECUTE_METHOD,
+                self::INVOKE_METHOD,
                 implode(', ', $publicMethodNames),
             ),
         );
@@ -141,9 +145,9 @@ final class ActionExecuteMethodRule implements Rule
     {
         return $this->createError(
             sprintf(
-                'Action class "%s" must name its only public method "%s()", "%s()" given.',
+                'Action class "%s" must use only public "%s()" as its entry point, "%s()" given.',
                 $className,
-                self::EXECUTE_METHOD,
+                self::INVOKE_METHOD,
                 $methodName,
             ),
         );

--- a/src/Action/ArchAction.php
+++ b/src/Action/ArchAction.php
@@ -8,8 +8,8 @@ namespace Pekral\Arch\Action;
  * Base interface for action implementations.
  *
  * Actions represent single-purpose operations that orchestrate business logic.
- * Each action class must implement a single public `execute()` method that serves
- * as the entry point for the action's functionality.
+ * Each action class must expose exactly one public instance entry point: `__invoke()`.
+ * No other public methods are allowed (besides the constructor).
  *
  * Actions should be focused on a single responsibility and coordinate between
  * services, repositories, and other components to accomplish their goal.

--- a/src/stubs/action.stub
+++ b/src/stubs/action.stub
@@ -13,7 +13,7 @@ final readonly class {{ class }} implements ArchAction
     {
     }
 
-    public function execute(): void
+    public function __invoke(): void
     {
         // TODO: Implement action logic
     }

--- a/tests/Unit/Actions/User/BulkDeleteUsersByParamsTest.php
+++ b/tests/Unit/Actions/User/BulkDeleteUsersByParamsTest.php
@@ -10,7 +10,7 @@ test('bulk delete by params deletes matching records', function (): void {
     User::factory()->count(5)->create(['name' => 'John']);
     User::factory()->count(3)->create(['name' => 'Jane']);
 
-    $bulkDeleteAction->execute(['name' => 'John']);
+    ($bulkDeleteAction)(['name' => 'John']);
 
     expect(User::query()->where('name', 'John')->count())->toBe(0)
         ->and(User::query()->where('name', 'Jane')->count())->toBe(3);
@@ -23,7 +23,7 @@ test('bulk delete by params with multiple conditions', function (): void {
     User::factory()->create(['name' => 'John', 'email' => 'john3@example.com']);
     User::factory()->create(['name' => 'Jane', 'email' => 'jane@example.com']);
 
-    $bulkDeleteAction->execute(['name' => 'John', 'email' => 'john1@example.com']);
+    ($bulkDeleteAction)(['name' => 'John', 'email' => 'john1@example.com']);
 
     expect(User::query()->where('name', 'John')->where('email', 'john1@example.com')->count())->toBe(0)
         ->and(User::query()->where('name', 'John')->count())->toBe(2);
@@ -33,7 +33,7 @@ test('bulk delete by params with no matching records does nothing', function ():
     $bulkDeleteAction = app(BulkDeleteUsersByParams::class);
     User::factory()->count(3)->create(['name' => 'John']);
 
-    $bulkDeleteAction->execute(['name' => 'NonExistent']);
+    ($bulkDeleteAction)(['name' => 'NonExistent']);
 
     expect(User::query()->where('name', 'John')->count())->toBe(3);
 });
@@ -42,7 +42,7 @@ test('bulk delete by params deletes all records when no conditions', function ()
     $bulkDeleteAction = app(BulkDeleteUsersByParams::class);
     User::factory()->count(5)->create();
 
-    $bulkDeleteAction->execute([]);
+    ($bulkDeleteAction)([]);
 
     expect(User::count())->toBe(0);
 });
@@ -50,7 +50,7 @@ test('bulk delete by params deletes all records when no conditions', function ()
 test('bulk delete by params with empty table does nothing', function (): void {
     $bulkDeleteAction = app(BulkDeleteUsersByParams::class);
 
-    $bulkDeleteAction->execute(['name' => 'John']);
+    ($bulkDeleteAction)(['name' => 'John']);
 
     expect(User::count())->toBe(0);
 });

--- a/tests/Unit/Actions/User/BulkImportUsersTest.php
+++ b/tests/Unit/Actions/User/BulkImportUsersTest.php
@@ -9,7 +9,7 @@ test('execute with empty data returns zero results', function (): void {
     $action = app(BulkImportUsers::class);
     $userData = [];
 
-    $result = $action->execute($userData);
+    $result = ($action)($userData);
 
     expect($result)->toBe([
         'created' => 0,
@@ -25,7 +25,7 @@ test('execute with new users creates all users', function (): void {
         ['name' => 'Jane Smith', 'email' => 'jane@example.com', 'password' => 'password456'],
     ];
 
-    $result = $action->execute($userData);
+    $result = ($action)($userData);
 
     expect($result['total_processed'])->toBe(2)
         ->and($result['created'])->toBe(2)
@@ -42,7 +42,7 @@ test('execute with mixed data handles existing and new users', function (): void
         ['name' => 'New User', 'email' => 'new@example.com', 'password' => 'password456'],
     ];
 
-    $result = $action->execute($userData);
+    $result = ($action)($userData);
 
     expect($result['total_processed'])->toBe(2)
         ->and($result['created'])->toBe(1)

--- a/tests/Unit/Actions/User/BulkOperationsDemoTest.php
+++ b/tests/Unit/Actions/User/BulkOperationsDemoTest.php
@@ -8,7 +8,7 @@ use Pekral\Arch\Tests\Models\User;
 test('execute performs bulk operations correctly', function (): void {
     $action = app(BulkOperationsDemo::class);
 
-    $result = $action->execute();
+    $result = ($action)();
 
     expect($result['bulk_create_result'])->toBe(3)
         ->and($result['insert_or_ignore_result'])->toBe(3)

--- a/tests/Unit/Actions/User/CountVerifiedUsersCachedTest.php
+++ b/tests/Unit/Actions/User/CountVerifiedUsersCachedTest.php
@@ -30,7 +30,7 @@ test('count verified users uses cache', function (): void {
         )
         ->andReturn(3);
 
-    $result = $countVerifiedUsersCached->handle();
+    $result = ($countVerifiedUsersCached)();
 
     expect($result)->toBe(3);
 });
@@ -50,7 +50,7 @@ test('count verified users skips cache when disabled', function (): void {
 
     $cacheMock->shouldNotReceive('remember');
 
-    $result = $countVerifiedUsersCached->handle();
+    $result = ($countVerifiedUsersCached)();
 
     expect($result)->toBe(3);
 });
@@ -68,7 +68,7 @@ test('count verified users with real database', function (): void {
     User::factory()->count(10)->create(['email_verified_at' => null]);
     $verifiedUsers = User::factory()->count(7)->create(['email_verified_at' => now()]);
     
-    $result = $countVerifiedUsersCached->handle();
+    $result = ($countVerifiedUsersCached)();
 
     expect($result)->toBe($verifiedUsers->count());
 });

--- a/tests/Unit/Actions/User/CountVerifiedUsersTest.php
+++ b/tests/Unit/Actions/User/CountVerifiedUsersTest.php
@@ -10,5 +10,5 @@ test('count verified users returns correct count', function (): void {
     User::factory()->count(10)->create(['email_verified_at' => null]);
     $verifiedUsers = User::factory()->count(10)->create(['email_verified_at' => now()]);
     
-    expect($countVerifiedUsers->handle())->toBe($verifiedUsers->count());
+    expect(($countVerifiedUsers)())->toBe($verifiedUsers->count());
 });

--- a/tests/Unit/Actions/User/CreateUserTest.php
+++ b/tests/Unit/Actions/User/CreateUserTest.php
@@ -14,7 +14,7 @@ test('create user with invalid data throws validation exception', function (): v
         'name' => 123,
     ];
 
-    $createUserAction->execute($data);
+    ($createUserAction)($data);
 })->throws(ValidationException::class);
 
 test('create user successfully creates user', function (): void {
@@ -26,7 +26,7 @@ test('create user successfully creates user', function (): void {
         'password' => fake()->password(),
     ];
 
-    $createUserAction->execute($data);
+    ($createUserAction)($data);
 
     $model = User::query()->where(['email' => $data['email']])->firstOrFail();
     expect($model->name)->toBe('Petr');

--- a/tests/Unit/Actions/User/DeleteUserByModelManagerTest.php
+++ b/tests/Unit/Actions/User/DeleteUserByModelManagerTest.php
@@ -9,7 +9,7 @@ test('delete by model manager removes user', function (): void {
     $deleteUser = app(DeleteUserByModelManager::class);
     $user = User::factory()->create();
 
-    $result = $deleteUser->handle($user);
+    $result = ($deleteUser)($user);
 
     expect($result)->toBeTrue()
         ->and(User::query()->find($user->id))->toBeNull();

--- a/tests/Unit/Actions/User/DeleteUserTest.php
+++ b/tests/Unit/Actions/User/DeleteUserTest.php
@@ -9,7 +9,7 @@ test('delete by model removes user', function (): void {
     $deleteUser = app(DeleteUser::class);
     $user = User::factory()->create();
     
-    $deleteUser->handle($user);
+    ($deleteUser)($user);
     
     expect(User::query()->find($user->id))->toBeNull();
 });
@@ -18,7 +18,7 @@ test('delete by params removes user', function (): void {
     $deleteUser = app(DeleteUser::class);
     $user = User::factory()->create();
     
-    $deleteUser->handle($user->id);
+    ($deleteUser)($user->id);
     
     expect(User::query()->find($user->id))->toBeNull();
 });

--- a/tests/Unit/Actions/User/GetOrCreateUserTest.php
+++ b/tests/Unit/Actions/User/GetOrCreateUserTest.php
@@ -11,7 +11,7 @@ test('get or create user creates new record', function (): void {
     $attributes = ['email' => 'newuser@example.com'];
     $values = ['name' => 'New User', 'password' => 'password123'];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result)->toBeInstanceOf(User::class)
         ->and($result->email)->toBe('newuser@example.com')
@@ -28,7 +28,7 @@ test('get or create user returns existing record', function (): void {
     $attributes = ['email' => 'existing@example.com'];
     $values = ['name' => 'Updated Name'];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result->id)->toBe($existingUser->id)
         ->and($result->email)->toBe('existing@example.com')
@@ -43,7 +43,7 @@ test('get or create user with invalid email', function (): void {
     $attributes = ['email' => 'invalid-email'];
     $values = ['name' => 'Test Name'];
     
-    $getOrCreateUserAction->execute($attributes, $values);
+    ($getOrCreateUserAction)($attributes, $values);
 })->throws(ValidationException::class);
 
 test('get or create user with missing email', function (): void {
@@ -51,7 +51,7 @@ test('get or create user with missing email', function (): void {
     $attributes = [];
     $values = ['name' => 'Test Name'];
     
-    $getOrCreateUserAction->execute($attributes, $values);
+    ($getOrCreateUserAction)($attributes, $values);
 })->throws(ValidationException::class);
 
 test('get or create user with missing name', function (): void {
@@ -59,7 +59,7 @@ test('get or create user with missing name', function (): void {
     $attributes = ['email' => fake()->email()];
     $values = [];
     
-    $getOrCreateUserAction->execute($attributes, $values);
+    ($getOrCreateUserAction)($attributes, $values);
 })->throws(ValidationException::class);
 
 test('get or create user transforms email to lowercase', function (): void {
@@ -67,7 +67,7 @@ test('get or create user transforms email to lowercase', function (): void {
     $attributes = ['email' => 'UPPERCASE@EXAMPLE.COM'];
     $values = ['name' => 'Test', 'password' => 'password123'];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result->email)->toBe('uppercase@example.com')
         ->and(User::query()->where('email', 'uppercase@example.com')->exists())->toBeTrue();
@@ -78,7 +78,7 @@ test('get or create user transforms name to ucfirst', function (): void {
     $attributes = ['email' => fake()->email()];
     $values = ['name' => 'lowercase name', 'password' => 'password123'];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result->name)->toBe('Lowercase name');
 });
@@ -88,7 +88,7 @@ test('get or create user with email in values', function (): void {
     $attributes = ['email' => 'test@example.com'];
     $values = ['email' => 'UPDATED@EXAMPLE.COM', 'name' => 'Test User', 'password' => 'password123'];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result->email)->toBe('updated@example.com')
         ->and($result->name)->toBe('Test user')
@@ -104,7 +104,7 @@ test('get or create user with only attributes', function (): void {
     ];
     $values = [];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result->email)->toBe('test@example.com')
         ->and($result->name)->toBe('test user');
@@ -122,7 +122,7 @@ test('get or create user returns existing with empty values', function (): void 
     ];
     $values = [];
     
-    $result = $getOrCreateUserAction->execute($attributes, $values);
+    $result = ($getOrCreateUserAction)($attributes, $values);
     
     expect($result->id)->toBe($existingUser->id);
     

--- a/tests/Unit/Actions/User/GetUserCachedTest.php
+++ b/tests/Unit/Actions/User/GetUserCachedTest.php
@@ -31,7 +31,7 @@ test('get user uses cache', function (): void {
         )
         ->andReturn($user);
 
-    $result = $getUserCached->handle($filters);
+    $result = ($getUserCached)($filters);
 
     expect($result->id)->toBe($user->id);
 });
@@ -51,7 +51,7 @@ test('get user skips cache when disabled', function (): void {
 
     $cacheMock->shouldNotReceive('remember');
 
-    $result = $getUserCached->handle($filters);
+    $result = ($getUserCached)($filters);
 
     expect($result->id)->toBe($user->id)
         ->and($result->name)->toBe($user->name)
@@ -70,7 +70,7 @@ test('get user with real database', function (): void {
     
     $user = User::factory()->create();
     
-    $foundUser = $getUserCached->handle(['name' => $user->name, 'email' => $user->email]);
+    $foundUser = ($getUserCached)(['name' => $user->name, 'email' => $user->email]);
     
     expect($foundUser->id)->toBe($user->id)
         ->and($foundUser->name)->toBe($user->name)
@@ -89,5 +89,5 @@ test('get non existing user throws exception', function (): void {
     
     User::factory()->create();
     
-    $getUserCached->handle(['name' => fake()->name(), 'email' => fake()->email()]);
+    ($getUserCached)(['name' => fake()->name(), 'email' => fake()->email()]);
 })->throws(ModelNotFoundException::class);

--- a/tests/Unit/Actions/User/GetUserTest.php
+++ b/tests/Unit/Actions/User/GetUserTest.php
@@ -10,14 +10,14 @@ test('get non existing user throws exception', function (): void {
     $getUser = app(GetUser::class);
     User::factory()->create();
     
-    $getUser->handle(['name' => fake()->name(), 'email' => fake()->email()]);
+    ($getUser)(['name' => fake()->name(), 'email' => fake()->email()]);
 })->throws(ModelNotFoundException::class);
 
 test('get user returns correct user', function (): void {
     $getUser = app(GetUser::class);
     $user = User::factory()->create();
     
-    $foundUser = $getUser->handle(['name' => $user->name, 'email' => $user->email]);
+    $foundUser = ($getUser)(['name' => $user->name, 'email' => $user->email]);
     
     expect($foundUser->id)->toBe($user->id)
         ->and($foundUser->name)->toBe($user->name)

--- a/tests/Unit/Actions/User/GetUsersCachedTest.php
+++ b/tests/Unit/Actions/User/GetUsersCachedTest.php
@@ -37,7 +37,7 @@ test('get users uses cache', function (): void {
         )
         ->andReturn($expectedResult);
 
-    $result = $getUsersCached->handle();
+    $result = ($getUsersCached)();
 
     expect($result)->toBeInstanceOf(LengthAwarePaginator::class)
         ->and($result->total())->toBe($expectedResult->total());
@@ -57,7 +57,7 @@ test('get users skips cache when disabled', function (): void {
 
     $cacheMock->shouldNotReceive('remember');
 
-    $result = $getUsersCached->handle();
+    $result = ($getUsersCached)();
 
     expect($result)->toBeInstanceOf(LengthAwarePaginator::class)
         ->and($result)->toHaveCount(config()->integer('arch.default_items_per_page'));
@@ -76,7 +76,7 @@ test('get users with real database', function (): void {
     $users = User::factory()->count(30)->create();
     $usersIds = $users->pluck('id')->toArray();
 
-    $foundUsers = $getUsersCached->handle();
+    $foundUsers = ($getUsersCached)();
 
     expect($foundUsers)->toHaveCount(config()->integer('arch.default_items_per_page'));
     
@@ -115,7 +115,7 @@ test('get users with filters uses cache', function (): void {
         )
         ->andReturn($expectedResult);
 
-    $result = $getUsersCached->handle($filters);
+    $result = ($getUsersCached)($filters);
 
     expect($result)->toBeInstanceOf(LengthAwarePaginator::class)
         ->and($result->total())->toBe($expectedResult->total());
@@ -134,7 +134,7 @@ test('get users with filters real database', function (): void {
     User::factory()->count(5)->create(['name' => 'John']);
     User::factory()->count(5)->create(['name' => 'Jane']);
 
-    $foundUsers = $getUsersCached->handle(['name' => 'John']);
+    $foundUsers = ($getUsersCached)(['name' => 'John']);
 
     expect($foundUsers)->toHaveCount(5);
     

--- a/tests/Unit/Actions/User/GetUsersTest.php
+++ b/tests/Unit/Actions/User/GetUsersTest.php
@@ -10,7 +10,7 @@ test('get users returns paginated users', function (): void {
     $users = User::factory()->count(30)->create();
     $usersIds = $users->pluck('id')->toArray();
 
-    $foundUsers = $getUsers->handle();
+    $foundUsers = ($getUsers)();
 
     expect($foundUsers)->toHaveCount(config()->integer('arch.default_items_per_page'));
     
@@ -24,7 +24,7 @@ test('get users with filters returns filtered users', function (): void {
     User::factory()->count(5)->create(['name' => 'John']);
     User::factory()->count(5)->create(['name' => 'Jane']);
     
-    $foundUsers = $getUsers->handle(['name' => 'John']);
+    $foundUsers = ($getUsers)(['name' => 'John']);
     
     expect($foundUsers)->toHaveCount(5);
     

--- a/tests/Unit/Actions/User/ImportUsersTest.php
+++ b/tests/Unit/Actions/User/ImportUsersTest.php
@@ -19,11 +19,11 @@ test('import users imports all users', function (): void {
         ],
     ];
     
-    expect($importUsers->handle($data))->toBe(count($data));
+    expect(($importUsers)($data))->toBe(count($data));
 });
 
 test('import users without data returns zero', function (): void {
     $importUsers = app(ImportUsers::class);
     
-    expect($importUsers->handle([]))->toBe(0);
+    expect(($importUsers)([]))->toBe(0);
 });

--- a/tests/Unit/Actions/User/RefreshUsersTest.php
+++ b/tests/Unit/Actions/User/RefreshUsersTest.php
@@ -17,11 +17,11 @@ test('refresh users refreshes all users', function (): void {
 
     /** @var array<int, array<mixed>> $data */
     $data = $refreshedData->values()->toArray();
-    expect($refreshUsers->handle($data))->toBe($refreshedData->count());
+    expect(($refreshUsers)($data))->toBe($refreshedData->count());
 });
 
 test('import users without data returns zero', function (): void {
     $refreshUsers = app(RefreshUsers::class);
     
-    expect($refreshUsers->handle([]))->toBe(0);
+    expect(($refreshUsers)([]))->toBe(0);
 });

--- a/tests/Unit/Actions/User/SearchUserCachedTest.php
+++ b/tests/Unit/Actions/User/SearchUserCachedTest.php
@@ -30,7 +30,7 @@ test('search user uses cache', function (): void {
         )
         ->andReturn($user);
 
-    $result = $searchUserCached->handle($filters);
+    $result = ($searchUserCached)($filters);
 
     expect($result)->not->toBeNull();
     
@@ -53,7 +53,7 @@ test('search user skips cache when disabled', function (): void {
 
     $cacheMock->shouldNotReceive('remember');
 
-    $result = $searchUserCached->handle($filters);
+    $result = ($searchUserCached)($filters);
 
     expect($result)->not->toBeNull();
     
@@ -75,7 +75,7 @@ test('search user with real database', function (): void {
     
     $user = User::factory()->create();
     
-    $foundUser = $searchUserCached->handle(['name' => $user->name, 'email' => $user->email]);
+    $foundUser = ($searchUserCached)(['name' => $user->name, 'email' => $user->email]);
     
     expect($foundUser)->not->toBeNull();
     
@@ -97,7 +97,7 @@ test('search non existing user returns null', function (): void {
     
     User::factory()->create();
     
-    $foundUser = $searchUserCached->handle(['name' => fake()->name(), 'email' => fake()->email()]);
+    $foundUser = ($searchUserCached)(['name' => fake()->name(), 'email' => fake()->email()]);
     
     expect($foundUser)->toBeNull();
 });
@@ -124,7 +124,7 @@ test('search non existing user caches null', function (): void {
         )
         ->andReturn(null);
 
-    $result = $searchUserCached->handle($filters);
+    $result = ($searchUserCached)($filters);
     
     expect($result)->toBeNull();
 });

--- a/tests/Unit/Actions/User/SearchUserTest.php
+++ b/tests/Unit/Actions/User/SearchUserTest.php
@@ -9,7 +9,7 @@ test('search user finds existing user', function (): void {
     $searchUser = app(SearchUser::class);
     $user = User::factory()->create();
     
-    $foundUser = $searchUser->handle(['name' => $user->name, 'email' => $user->email]);
+    $foundUser = ($searchUser)(['name' => $user->name, 'email' => $user->email]);
     
     expect($foundUser)->not->toBeNull();
     
@@ -23,7 +23,7 @@ test('search non existing user returns null', function (): void {
     $searchUser = app(SearchUser::class);
     User::factory()->create();
     
-    $foundUser = $searchUser->handle(['name' => fake()->name(), 'email' => fake()->email()]);
+    $foundUser = ($searchUser)(['name' => fake()->name(), 'email' => fake()->email()]);
     
     expect($foundUser)->toBeNull();
 });

--- a/tests/Unit/Actions/User/SendWelcomeEmailWithLoggingTest.php
+++ b/tests/Unit/Actions/User/SendWelcomeEmailWithLoggingTest.php
@@ -12,7 +12,7 @@ test('execute sends email successfully', function (): void {
     assert($user instanceof User);
     $action = new SendWelcomeEmailWithLogging();
 
-    $action->execute($user, ['source' => 'registration']);
+    ($action)($user, ['source' => 'registration']);
 
     expect(true)->toBeTrue();
 });
@@ -24,7 +24,7 @@ test('execute sends email with empty context', function (): void {
     assert($user instanceof User);
     $action = new SendWelcomeEmailWithLogging();
 
-    $action->execute($user);
+    ($action)($user);
 
     expect(true)->toBeTrue();
 });
@@ -40,7 +40,7 @@ test('execute with custom context', function (): void {
     ];
     $action = new SendWelcomeEmailWithLogging();
 
-    $action->execute($user, $context);
+    ($action)($user, $context);
 
     expect(true)->toBeTrue();
 });

--- a/tests/Unit/Actions/User/UpdateOrCreateUserTest.php
+++ b/tests/Unit/Actions/User/UpdateOrCreateUserTest.php
@@ -11,7 +11,7 @@ test('update or create user creates new record', function (): void {
     $attributes = ['email' => 'newuser@example.com'];
     $values = ['name' => 'New User', 'password' => 'password123'];
     
-    $result = $updateOrCreateUserAction->execute($attributes, $values);
+    $result = ($updateOrCreateUserAction)($attributes, $values);
     
     expect($result)->toBeInstanceOf(User::class)
         ->and($result->email)->toBe('newuser@example.com')
@@ -28,7 +28,7 @@ test('update or create user updates existing record', function (): void {
     $attributes = ['email' => 'existing@example.com'];
     $values = ['name' => 'Updated Name'];
     
-    $result = $updateOrCreateUserAction->execute($attributes, $values);
+    $result = ($updateOrCreateUserAction)($attributes, $values);
     
     expect($result->id)->toBe($existingUser->id)
         ->and($result->email)->toBe('existing@example.com')
@@ -43,7 +43,7 @@ test('update or create user with invalid email', function (): void {
     $attributes = ['email' => 'invalid-email'];
     $values = ['name' => 'Test Name'];
     
-    $updateOrCreateUserAction->execute($attributes, $values);
+    ($updateOrCreateUserAction)($attributes, $values);
 })->throws(ValidationException::class);
 
 test('update or create user with missing email', function (): void {
@@ -51,7 +51,7 @@ test('update or create user with missing email', function (): void {
     $attributes = [];
     $values = ['name' => 'Test Name'];
     
-    $updateOrCreateUserAction->execute($attributes, $values);
+    ($updateOrCreateUserAction)($attributes, $values);
 })->throws(ValidationException::class);
 
 test('update or create user with missing name', function (): void {
@@ -59,7 +59,7 @@ test('update or create user with missing name', function (): void {
     $attributes = ['email' => fake()->email()];
     $values = [];
     
-    $updateOrCreateUserAction->execute($attributes, $values);
+    ($updateOrCreateUserAction)($attributes, $values);
 })->throws(ValidationException::class);
 
 test('update or create user transforms email to lowercase', function (): void {
@@ -67,7 +67,7 @@ test('update or create user transforms email to lowercase', function (): void {
     $attributes = ['email' => 'UPPERCASE@EXAMPLE.COM'];
     $values = ['name' => 'Test', 'password' => 'password123'];
     
-    $result = $updateOrCreateUserAction->execute($attributes, $values);
+    $result = ($updateOrCreateUserAction)($attributes, $values);
     
     expect($result->email)->toBe('uppercase@example.com')
         ->and(User::query()->where('email', 'uppercase@example.com')->exists())->toBeTrue();
@@ -78,7 +78,7 @@ test('update or create user transforms name to ucfirst', function (): void {
     $attributes = ['email' => fake()->email()];
     $values = ['name' => 'lowercase name', 'password' => 'password123'];
     
-    $result = $updateOrCreateUserAction->execute($attributes, $values);
+    $result = ($updateOrCreateUserAction)($attributes, $values);
     
     expect($result->name)->toBe('Lowercase name');
 });
@@ -88,7 +88,7 @@ test('update or create user with email in values', function (): void {
     $attributes = ['email' => 'test@example.com'];
     $values = ['email' => 'UPDATED@EXAMPLE.COM', 'name' => 'Test User', 'password' => 'password123'];
     
-    $result = $updateOrCreateUserAction->execute($attributes, $values);
+    $result = ($updateOrCreateUserAction)($attributes, $values);
     
     expect($result->email)->toBe('updated@example.com')
         ->and($result->name)->toBe('Test user')
@@ -104,7 +104,7 @@ test('update or create user with only attributes', function (): void {
     ];
     $values = [];
     
-    $result = $updateOrCreateUserAction->execute($attributes, $values);
+    $result = ($updateOrCreateUserAction)($attributes, $values);
     
     expect($result->email)->toBe('test@example.com')
         ->and($result->name)->toBe('test user');

--- a/tests/Unit/Actions/User/UpdateUserNameActionTest.php
+++ b/tests/Unit/Actions/User/UpdateUserNameActionTest.php
@@ -10,7 +10,7 @@ test('update user name updates correctly', function (): void {
     $user = User::factory()->create(['name' => 'john']);
     $newName = 'John';
     
-    $updateUserName->handle($newName, $user);
+    ($updateUserName)($newName, $user);
     
     $user->fresh();
     expect($user->name)->toBe($newName);

--- a/tests/Unit/Actions/User/UpdateUserTest.php
+++ b/tests/Unit/Actions/User/UpdateUserTest.php
@@ -17,7 +17,7 @@ test('update user with valid data', function (): void {
         'name' => 'new name',
     ];
 
-    $result = $updateUserAction->execute($user, $data);
+    $result = ($updateUserAction)($user, $data);
 
     expect($result)->toBe($user);
     
@@ -34,7 +34,7 @@ test('update user with invalid email throws exception', function (): void {
         'name' => 'Test Name',
     ];
 
-    $updateUserAction->execute($user, $data);
+    ($updateUserAction)($user, $data);
 })->throws(ValidationException::class);
 
 test('update user with missing email throws exception', function (): void {
@@ -44,7 +44,7 @@ test('update user with missing email throws exception', function (): void {
         'name' => 'Test Name',
     ];
 
-    $updateUserAction->execute($user, $data);
+    ($updateUserAction)($user, $data);
 })->throws(ValidationException::class);
 
 test('update user with missing name throws exception', function (): void {
@@ -54,7 +54,7 @@ test('update user with missing name throws exception', function (): void {
         'email' => fake()->email(),
     ];
 
-    $updateUserAction->execute($user, $data);
+    ($updateUserAction)($user, $data);
 })->throws(ValidationException::class);
 
 test('update user transforms email to lowercase', function (): void {
@@ -65,7 +65,7 @@ test('update user transforms email to lowercase', function (): void {
         'name' => 'Test',
     ];
 
-    $updateUserAction->execute($user, $data);
+    ($updateUserAction)($user, $data);
 
     $user->refresh();
     expect($user->email)->toBe('uppercase@example.com');
@@ -79,7 +79,7 @@ test('update user transforms name to ucfirst', function (): void {
         'name' => 'lowercase name',
     ];
 
-    $updateUserAction->execute($user, $data);
+    ($updateUserAction)($user, $data);
 
     $user->refresh();
     expect($user->name)->toBe('Lowercase name');
@@ -90,5 +90,5 @@ test('update user with empty data throws exception', function (): void {
     $updateUserAction = app(UpdateUser::class);
     $data = [];
 
-    $updateUserAction->execute($user, $data);
+    ($updateUserAction)($user, $data);
 })->throws(ValidationException::class);

--- a/tests/Unit/Actions/User/VerifyUserActionTest.php
+++ b/tests/Unit/Actions/User/VerifyUserActionTest.php
@@ -12,7 +12,7 @@ test('verification sends notification', function (): void {
     $verifyUserAction = app(VerifyUserAction::class);
     $user = User::factory()->create();
 
-    $verifyUserAction->handle($user);
+    ($verifyUserAction)($user);
 
     Notification::assertSentTo($user, VerifyEmail::class);
 });
@@ -22,7 +22,7 @@ test('verification has been sent skips notification', function (): void {
     $verifyUserAction = app(VerifyUserAction::class);
     $user = User::factory()->create(['email_verified_at' => now()]);
     
-    $verifyUserAction->handle($user);
+    ($verifyUserAction)($user);
     
     Notification::assertNothingSent();
 });

--- a/tests/Unit/Console/Commands/MakeArchActionCommandTest.php
+++ b/tests/Unit/Console/Commands/MakeArchActionCommandTest.php
@@ -29,7 +29,7 @@ final class MakeArchActionCommandTest extends TestCase
         $this->assertStringContainsString('namespace App\Actions;', $content);
         $this->assertStringContainsString('final readonly class TestAction implements ArchAction', $content);
         $this->assertStringContainsString('use Pekral\Arch\Action\ArchAction;', $content);
-        $this->assertStringContainsString('public function execute(): void', $content);
+        $this->assertStringContainsString('public function __invoke(): void', $content);
     }
 
     public function testCreatesActionInSubdirectory(): void


### PR DESCRIPTION
## Shrnutí

- Akce implementující `ArchAction` používají jako jediný veřejný vstupní bod (kromě konstruktoru) metodu `__invoke()`.
- PHPStan pravidlo `ActionInvokeMethodRule` nahrazuje `ActionExecuteMethodRule` a vyžaduje právě jednu veřejnou `__invoke()`; další veřejné metody jsou zakázané.
- Příklady, šablona `make:arch-action`, dokumentace a testy jsou sladěné (volitelná syntax `($action)(…)`).

## Breaking change

Hostitelské aplikace musí přejmenovat `execute()` / `handle()` na `__invoke()` a volat akce jako callable (např. `($createUser)($data)`), případně předávat instanci tam, kde se očekává `callable`.

## Testy

Změny jsou pokryté existujícími Pest testy v `tests/Unit/Actions/User/*` a `MakeArchActionCommandTest`; doporučení k ručnímu ověření viz sekce níže.

## Doporučení k ověření (manuálně / CI)

1. `composer build` — projde celý quality pipeline včetně PHPStan a coverage.
2. V konzumní aplikaci: nahradit volání `->execute()` / `->handle()` u akcí za `__invoke` nebo `($action)(…)`.
3. `php artisan make:arch-action` — vygenerovaná třída obsahuje `public function __invoke(): void`.

## Zdroje

- [PHP: The __invoke() method](https://www.php.net/manual/en/language.oop5.magic.php#object.invoke)
