### PR TITLE
refactor(result): remove unwrapOr method from Result pattern

### DIFF
--- a/src/Result/Failure.php
+++ b/src/Result/Failure.php
@@ -34,11 +34,6 @@ final readonly class Failure extends Result
         throw UnwrapFailure::fromResult($this->error);
     }
 
-    public function unwrapOr(mixed $default): mixed
-    {
-        return $default;
-    }
-
     /**
      * @return TError
      */

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -28,15 +28,6 @@ abstract readonly class Result
     abstract public function unwrap(): mixed;
 
     /**
-     * Return the success value or the provided default.
-     *
-     * @template TDefault
-     * @param TDefault $default
-     * @return TSuccess|TDefault
-     */
-    abstract public function unwrapOr(mixed $default): mixed;
-
-    /**
      * Return the error value or throw if this is a success.
      *
      * @return TError

--- a/src/Result/Success.php
+++ b/src/Result/Success.php
@@ -34,15 +34,6 @@ final readonly class Success extends Result
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
-     * @return TSuccess
-     */
-    public function unwrapOr(mixed $default): mixed
-    {
-        return $this->value;
-    }
-
-    /**
      * @throws \Pekral\Arch\Result\UnwrapFailure
      * @return never
      */

--- a/tests/Unit/Result/FailureTest.php
+++ b/tests/Unit/Result/FailureTest.php
@@ -30,12 +30,6 @@ test('failure unwrap throws', function (): void {
     $failure->unwrap();
 })->throws(UnwrapFailure::class, 'Cannot unwrap a failure Result.');
 
-test('failure unwrapOr returns the default', function (): void {
-    $failure = new Failure('error');
-
-    expect($failure->unwrapOr('fallback'))->toBe('fallback');
-});
-
 test('failure error returns the error', function (): void {
     $failure = new Failure('my error');
 

--- a/tests/Unit/Result/ResultTest.php
+++ b/tests/Unit/Result/ResultTest.php
@@ -37,18 +37,6 @@ test('unwrap throws with enum message on failure with backed enum', function ():
     $result->unwrap();
 })->throws(UnwrapFailure::class, 'Cannot unwrap a failure Result. Error: validation_failed');
 
-test('unwrapOr returns the value on success', function (): void {
-    $result = Result::success('real');
-
-    expect($result->unwrapOr('default'))->toBe('real');
-});
-
-test('unwrapOr returns the default on failure', function (): void {
-    $result = Result::failure('error');
-
-    expect($result->unwrapOr('default'))->toBe('default');
-});
-
 test('error returns the error on failure', function (): void {
     $result = Result::failure('my error');
 

--- a/tests/Unit/Result/SuccessTest.php
+++ b/tests/Unit/Result/SuccessTest.php
@@ -30,12 +30,6 @@ test('success unwrap returns the value', function (): void {
     expect($success->unwrap())->toBe('hello');
 });
 
-test('success unwrapOr returns the value ignoring default', function (): void {
-    $success = new Success('hello');
-
-    expect($success->unwrapOr('default'))->toBe('hello');
-});
-
 test('success error throws', function (): void {
     $success = new Success('value');
 


### PR DESCRIPTION
## Summary
- Removed `unwrapOr()` method from `Result`, `Success`, and `Failure` classes
- Removed all related tests for `unwrapOr` in `SuccessTest`, `FailureTest`, and `ResultTest`

Closes #91

## Related
- https://github.com/pekral/arch-app-services/issues/91

## Test plan
- [x] All existing Result tests pass (31 tests, 54 assertions)
- [x] PHPStan analysis passes with no errors
- [x] Full test suite passes (284 tests, 678 assertions)
- [x] Code fixers (Rector, Pint, PHPCS) report no issues