### PR TITLE
feat(phpstan): ActionInvokeArgumentsRule — enforce no-arg action invocation

### DIFF
--- a/examples/Actions/User/VerifyUserAction.php
+++ b/examples/Actions/User/VerifyUserAction.php
@@ -6,10 +6,13 @@ namespace Pekral\Arch\Examples\Actions\User;
 
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Support\Facades\Notification;
-use Pekral\Arch\Action\ArchAction;
 use Pekral\Arch\Tests\Models\User;
 
-final readonly class VerifyUserAction implements ArchAction
+/**
+ * Sends an email verification notification to a user who has not yet verified their address.
+ * This is an internal helper invoked by entry-point actions — not an ArchAction entry point itself.
+ */
+final readonly class VerifyUserAction
 {
 
     public function __invoke(User $user): void

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,10 +11,10 @@ parameters:
         - phpstan
     tmpDir: build/phpstan
     treatPhpDocTypesAsCertain: false
-    
+
     bootstrapFiles:
         - vendor/autoload.php
-    
+
     scanDirectories:
         - phpstan
 
@@ -57,5 +57,9 @@ services:
             - phpstan.rules.rule
     -
         class: Pekral\Arch\PHPStan\Rules\OnlyRepositoriesCanQueryDataRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\ActionInvokeArgumentsRule
         tags:
             - phpstan.rules.rule

--- a/phpstan.test.neon
+++ b/phpstan.test.neon
@@ -21,3 +21,7 @@ services:
         class: Pekral\Arch\PHPStan\Rules\OnlyRepositoriesCanQueryDataRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\ActionInvokeArgumentsRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan/Rules/ActionInvokeArgumentsRule.php
+++ b/phpstan/Rules/ActionInvokeArgumentsRule.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Enforces that ArchAction instances are always invoked without arguments.
+ *
+ * All inputs to an action must be provided via constructor injection.
+ * Calling an action with arguments (e.g. `$action($a, $b)`) breaks the
+ * readonly DI pattern and is forbidden — use `$action()` instead.
+ *
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\FuncCall>
+ */
+final readonly class ActionInvokeArgumentsRule implements Rule
+{
+
+    private const string ARCH_ACTION_INTERFACE = 'Pekral\Arch\Action\ArchAction';
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\FuncCall $node
+     * @return array<int, \PHPStan\Rules\RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof FuncCall) {
+            return [];
+        }
+
+        // Named function calls like foo() are not action invocations
+        if ($node->name instanceof Node\Name) {
+            return [];
+        }
+
+        if (!$node->name instanceof Node\Expr) {
+            return [];
+        }
+
+        // No arguments — valid pattern: $action()
+        if ($node->args === []) {
+            return [];
+        }
+
+        $calleeType = $scope->getType($node->name);
+
+        if (!$this->isArchAction($calleeType)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'ArchAction must be invoked without arguments. Provide all inputs via constructor injection and call the action as $action().',
+            )->build(),
+        ];
+    }
+
+    private function isArchAction(Type $type): bool
+    {
+        return new ObjectType(self::ARCH_ACTION_INTERFACE)
+            ->isSuperTypeOf($type)
+            ->yes();
+    }
+
+}

--- a/tests/PHPStan/Rules/ActionInvokeArgumentsRuleTest.php
+++ b/tests/PHPStan/Rules/ActionInvokeArgumentsRuleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+use Pekral\Arch\Tests\PHPStan\Helpers\PhpstanFixtureRunner;
+
+test('ActionInvokeArgumentsRule forbids passing arguments when invoking an ArchAction', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/ActionInvokeArgumentsRule',
+    );
+
+    $expectedMessage = 'ArchAction must be invoked without arguments. Provide all inputs via constructor injection and call the action as $action().';
+
+    // Valid invocation — no errors expected
+    expect($errors)->not->toHaveKey('ValidActionInvocation.php');
+
+    // Non-action callable with arguments — no errors expected
+    expect($errors)->not->toHaveKey('NonActionCalledWithArguments.php');
+
+    // Action called with arguments via normal syntax
+    expect($errors['ActionCalledWithArguments.php'] ?? [])->toContain($expectedMessage);
+
+    // Action called with arguments via parenthesized syntax: ($action)($arg1, $arg2)
+    expect($errors['ActionCalledWithParenthesizedSyntax.php'] ?? [])->toContain($expectedMessage);
+});

--- a/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/ActionCalledWithArguments.php
+++ b/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/ActionCalledWithArguments.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\ActionInvokeArgumentsRule;
+
+use Pekral\Arch\Action\ArchAction;
+
+final readonly class ActionWithParams implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+    }
+
+}
+
+final class ActionCalledWithArguments
+{
+
+    public function run(ActionWithParams $action): void
+    {
+        // Invalid: arguments passed to action invocation
+        $action('foo', 'bar');
+    }
+
+}

--- a/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/ActionCalledWithParenthesizedSyntax.php
+++ b/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/ActionCalledWithParenthesizedSyntax.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\ActionInvokeArgumentsRule;
+
+use Pekral\Arch\Action\ArchAction;
+
+final readonly class ParenthesizedAction implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+    }
+
+}
+
+final class ActionCalledWithParenthesizedSyntax
+{
+
+    public function run(ParenthesizedAction $action, string $project): void
+    {
+        // Invalid: parenthesized syntax with arguments — ($action)($arg1, $arg2)
+        ($action)($project, 'extra');
+    }
+
+}

--- a/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/NonActionCalledWithArguments.php
+++ b/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/NonActionCalledWithArguments.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\ActionInvokeArgumentsRule;
+
+final class NotAnAction
+{
+
+    public function __invoke(string $name): void
+    {
+    }
+
+}
+
+final class NonActionCalledWithArguments
+{
+
+    public function run(NotAnAction $obj): void
+    {
+        // Valid: not an ArchAction, arguments are allowed
+        $obj('foo');
+    }
+
+}

--- a/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/ValidActionInvocation.php
+++ b/tests/fixtures/PHPStan/ActionInvokeArgumentsRule/ValidActionInvocation.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\ActionInvokeArgumentsRule;
+
+use Pekral\Arch\Action\ArchAction;
+
+final readonly class SomeAction implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+    }
+
+}
+
+final class ValidActionInvocation
+{
+
+    public function run(SomeAction $action): void
+    {
+        // Valid: no arguments passed to the action
+        $action();
+    }
+
+}


### PR DESCRIPTION
## Řeší

Closes #95

## Popis změny

Přidáno nové PHPStan pravidlo **`ActionInvokeArgumentsRule`**, které zabraňuje volání `ArchAction` instancí s argumenty. Akce musí být vždy volány jako `$action()` bez parametrů — veškeré vstupy se poskytují přes constructor injection.

### Co pravidlo zachycuje

```php
// ❌ Zakázáno — argumenty při volání akce
$action($project, $data);
($action)($project, $result['source'], $result['sqlPaths']);

// ✅ Povoleno — volání bez argumentů
$action();
```

## Změny

- `phpstan/Rules/ActionInvokeArgumentsRule.php` — nové PHPStan pravidlo
- `phpstan.neon` + `phpstan.test.neon` — registrace pravidla
- `tests/PHPStan/Rules/ActionInvokeArgumentsRuleTest.php` — testy pravidla
- `tests/fixtures/PHPStan/ActionInvokeArgumentsRule/` — fixture soubory (valid/invalid scénáře)
- `examples/Actions/User/VerifyUserAction.php` — odstraněno `ArchAction` interface; třída je interní helper volaný z jiné akce, ne vstupní bod

## Architektonické zdůvodnění

`VerifyUserAction` je volán _uvnitř_ `CreateUser` a dalších akcí — není to vstupní bod (controller/job/command → action). `ArchAction` interface by měl implementovat pouze skutečné vstupní body. Interní helpery smí mít parametry v `__invoke()`.

## Doporučení k testování

1. **Nové pravidlo:** Přidejte do libovolné třídy implementující `ArchAction` volání `$action($someArg)` — PHPStan musí vyhodit chybu `ArchAction must be invoked without arguments`.
2. **Validní pattern:** Volání `$action()` bez argumentů nesmí vyvolat žádnou chybu.
3. **Neakce:** Volání `$notAnAction($arg)` na třídě neimplementující `ArchAction` nesmí vyvolat chybu.
4. **Automatické testy:** `vendor/bin/pest tests/PHPStan/Rules/ActionInvokeArgumentsRuleTest.php`

Testy byly napsány: ✅