### PR TITLE
fix(phpstan): allow Eloquent scope calls on model instances in Actions

### DIFF
--- a/phpstan.test.neon
+++ b/phpstan.test.neon
@@ -25,3 +25,7 @@ services:
         class: Pekral\Arch\PHPStan\Rules\ActionInvokeArgumentsRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\NoDirectDatabaseQueriesInActionsRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan/Rules/NoDirectDatabaseQueriesInActionsRule.php
+++ b/phpstan/Rules/NoDirectDatabaseQueriesInActionsRule.php
@@ -146,6 +146,12 @@ final class NoDirectDatabaseQueriesInActionsRule implements Rule
             return [];
         }
 
+        // Scope calls on model instances read model state and do not initiate a database query on their own.
+        // Only restrict scope calls when invoked on a query builder.
+        if (!$this->isEloquentBuilder($callerType)) {
+            return [];
+        }
+
         return $this->createScopeErrorMessage($methodName);
     }
 
@@ -336,6 +342,13 @@ final class NoDirectDatabaseQueriesInActionsRule implements Rule
         $queryBuilderType = new ObjectType('Illuminate\Database\Eloquent\Builder');
 
         return $eloquentModelType->isSuperTypeOf($type)->yes() || $queryBuilderType->isSuperTypeOf($type)->yes();
+    }
+
+    private function isEloquentBuilder(Type $type): bool
+    {
+        $queryBuilderType = new ObjectType('Illuminate\Database\Eloquent\Builder');
+
+        return $queryBuilderType->isSuperTypeOf($type)->yes();
     }
 
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Pekral\Arch\Tests\Models;
 
 use Iksaku\Laravel\MassUpdate\MassUpdatable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -20,6 +21,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Carbon\Carbon|null $deleted_at
  * @method static \Illuminate\Database\Eloquent\Builder<\Pekral\Arch\Tests\Models\User> whereName(string $value)
  * @method static \Illuminate\Database\Eloquent\Builder<\Pekral\Arch\Tests\Models\User> whereEmail(string $value)
+ * @method static \Illuminate\Database\Eloquent\Builder<\Pekral\Arch\Tests\Models\User> active()
  */
 final class User extends Model
 {
@@ -47,6 +49,17 @@ final class User extends Model
         'deleted_at' => 'datetime',
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * Scope to filter only active (email-verified) users.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<self> $query
+     * @return \Illuminate\Database\Eloquent\Builder<self>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNotNull('email_verified_at');
+    }
 
     protected static function newFactory(): UserFactory
     {

--- a/tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php
+++ b/tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+use Pekral\Arch\Tests\PHPStan\Helpers\PhpstanFixtureRunner;
+
+test('NoDirectDatabaseQueriesInActionsRule blocks forbidden query builder methods in Actions', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule',
+    );
+
+    expect($errors)->toHaveKey('ActionWithForbiddenQueryMethods.php');
+
+    $forbiddenErrors = $errors['ActionWithForbiddenQueryMethods.php'];
+    expect($forbiddenErrors)
+        ->toContain('Query builder method "where()" cannot be called in Action classes. Data retrieval with conditions must be in Repository class.')
+        ->toContain('Query builder method "orderBy()" cannot be called in Action classes. Data retrieval with conditions must be in Repository class.');
+});
+
+test('NoDirectDatabaseQueriesInActionsRule blocks scope chained before retrieval on a query builder in Actions', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule',
+    );
+
+    expect($errors)->toHaveKey('ActionWithBuilderScopeChain.php');
+
+    $scopeErrors = $errors['ActionWithBuilderScopeChain.php'];
+    expect($scopeErrors)->toContain(
+        'Eloquent scope "active()" cannot be called in Action classes. Data retrieval with conditions must be in Repository class.',
+    );
+});
+
+test('NoDirectDatabaseQueriesInActionsRule allows scope calls on model instances in Actions', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule',
+    );
+
+    $instanceErrors = $errors['ActionWithScopeOnModelInstance.php'] ?? [];
+    $scopeErrors = array_filter(
+        $instanceErrors,
+        static fn (string $msg): bool => str_contains($msg, 'Eloquent scope "active()"'),
+    );
+
+    expect($scopeErrors)->toBeEmpty();
+});

--- a/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithAllowedRetrievalOnly.php
+++ b/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithAllowedRetrievalOnly.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoDirectDatabaseQueriesInActionsRule;
+
+use Pekral\Arch\Action\ArchAction;
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Action that calls only safe retrieval methods without conditions — must NOT trigger errors.
+ */
+final readonly class ActionWithAllowedRetrievalOnly implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+        User::query()->get();
+        User::query()->first();
+        User::query()->count();
+    }
+
+}

--- a/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithBuilderScopeChain.php
+++ b/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithBuilderScopeChain.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoDirectDatabaseQueriesInActionsRule;
+
+use Pekral\Arch\Action\ArchAction;
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Action that chains a scope on a query builder before a retrieval method — must trigger an error.
+ */
+final readonly class ActionWithBuilderScopeChain implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+        User::query()->active()->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithForbiddenQueryMethods.php
+++ b/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithForbiddenQueryMethods.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoDirectDatabaseQueriesInActionsRule;
+
+use Pekral\Arch\Action\ArchAction;
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Action that uses forbidden query builder methods directly — must trigger errors.
+ */
+final readonly class ActionWithForbiddenQueryMethods implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+        User::query()->where('name', 'test')->get();
+        User::query()->orderBy('name')->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithScopeOnModelInstance.php
+++ b/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithScopeOnModelInstance.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoDirectDatabaseQueriesInActionsRule;
+
+use Pekral\Arch\Action\ArchAction;
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Action that calls a scope on an already-loaded model instance — must NOT trigger an error.
+ * Reading model state via scopes is permitted in Actions.
+ */
+final readonly class ActionWithScopeOnModelInstance implements ArchAction
+{
+
+    public function __invoke(User $user): void
+    {
+        $user->active();
+    }
+
+}


### PR DESCRIPTION
## Summary

- `NoDirectDatabaseQueriesInActionsRule` was blocking all scope calls on Eloquent types in Action classes, including calls on already-loaded **model instances** (e.g. `$model->hasCreditPlan()`)
- Scope calls on a **model instance** do not initiate a new database query — they read model state and are permitted in Actions
- Scope calls on a **query builder** (e.g. `User::query()->active()->get()`) remain forbidden; data retrieval with conditions must stay in a Repository
- Added `isEloquentBuilder()` helper to distinguish between Builder and Model instance types
- Registered `NoDirectDatabaseQueriesInActionsRule` in `phpstan.test.neon` and added full test coverage with fixture files

## Changes

- `phpstan/Rules/NoDirectDatabaseQueriesInActionsRule.php` — only restrict scope errors when caller is a query builder
- `phpstan.test.neon` — register the rule for test analysis
- `tests/Models/User.php` — add `scopeActive()` scope for fixture use
- `tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php` — new tests
- `tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/` — fixture files for all scenarios

## Test plan

- [ ] `vendor/bin/pest tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php` — all 3 tests pass
- [ ] Verify that `$model->hasCreditPlan()` style calls no longer produce PHPStan errors in Action classes
- [ ] Verify that `User::query()->active()->get()` still produces PHPStan errors in Action classes

Closes https://github.com/pekral/arch-app-services/issues/93

🤖 Generated with [Claude Code](https://claude.com/claude-code)