### PR TITLE
test(phpstan): extend NoDirectDatabaseQueriesInActionsRule test coverage

### DIFF
--- a/phpstan/Rules/NoDirectDatabaseQueriesInActionsRule.php
+++ b/phpstan/Rules/NoDirectDatabaseQueriesInActionsRule.php
@@ -114,11 +114,7 @@ final class NoDirectDatabaseQueriesInActionsRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$this->isValidMethodOrStaticCall($node)) {
-            return [];
-        }
-
-        if (!$this->isInActionClass($scope)) {
+        if (!$this->isApplicableContext($node, $scope)) {
             return [];
         }
 
@@ -218,10 +214,6 @@ final class NoDirectDatabaseQueriesInActionsRule implements Rule
             return ['method' => $methodName, 'type' => 'conditional'];
         }
 
-        if ($this->isSafeBuilderMethod($methodName)) {
-            return null;
-        }
-
         if ($this->isPotentialScope($node, $scope)) {
             return ['method' => $methodName, 'type' => 'scope'];
         }
@@ -237,21 +229,20 @@ final class NoDirectDatabaseQueriesInActionsRule implements Rule
 
         $methodName = $node->name->toString();
 
-        if ($this->isAllowedRetrievalMethod($methodName)
-            || $this->isAlwaysForbiddenMethod($methodName)
-            || $this->isSafeBuilderMethod($methodName)
-        ) {
-            return false;
-        }
-
-        $callerType = $scope->getType($node->var);
-
-        return $this->isEloquentModelOrBuilder($callerType);
+        return !$this->isAllowedRetrievalMethod($methodName)
+            && !$this->isAlwaysForbiddenMethod($methodName)
+            && !$this->isSafeBuilderMethod($methodName)
+            && $this->isEloquentModelOrBuilder($scope->getType($node->var));
     }
 
-    private function isValidMethodOrStaticCall(Node $node): bool
+    /**
+     * Returns true when the node is a method or static call made inside an Action class.
+     * Both conditions must hold to make the rule applicable.
+     */
+    private function isApplicableContext(Node $node, Scope $scope): bool
     {
-        return $node instanceof MethodCall || $node instanceof StaticCall;
+        return ($node instanceof MethodCall || $node instanceof StaticCall)
+            && $this->isInActionClass($scope);
     }
 
     private function getMethodName(Node $node): ?string

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -61,6 +61,15 @@ final class User extends Model
         return $query->whereNotNull('email_verified_at');
     }
 
+    /**
+     * Returns true when the user has a verified email address.
+     * This is a pure model helper that reads already-loaded state — no query is issued.
+     */
+    public function isActive(): bool
+    {
+        return $this->email_verified_at !== null;
+    }
+
     protected static function newFactory(): UserFactory
     {
         return UserFactory::new();

--- a/tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php
+++ b/tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php
@@ -43,3 +43,25 @@ test('NoDirectDatabaseQueriesInActionsRule allows scope calls on model instances
 
     expect($scopeErrors)->toBeEmpty();
 });
+
+test('NoDirectDatabaseQueriesInActionsRule allows boolean helper methods on model instances in Actions', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule',
+    );
+
+    expect($errors)->not->toHaveKey('ActionWithBooleanHelperMethod.php');
+});
+
+test('NoDirectDatabaseQueriesInActionsRule allows bare retrieval methods without conditions in Actions', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule',
+    );
+
+    // Filter only errors originating from this rule — other rules may flag the same fixture.
+    $ruleErrors = array_filter(
+        $errors['ActionWithAllowedRetrievalOnly.php'] ?? [],
+        static fn (string $msg): bool => str_contains($msg, 'cannot be called in Action classes'),
+    );
+
+    expect($ruleErrors)->toBeEmpty();
+});

--- a/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithBooleanHelperMethod.php
+++ b/tests/fixtures/PHPStan/NoDirectDatabaseQueriesInActionsRule/ActionWithBooleanHelperMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoDirectDatabaseQueriesInActionsRule;
+
+use Pekral\Arch\Action\ArchAction;
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Action that calls a boolean helper method on a loaded model instance — must NOT trigger an error.
+ * Helper methods read already-hydrated model state and do not issue a database query.
+ */
+final readonly class ActionWithBooleanHelperMethod implements ArchAction
+{
+
+    public function __invoke(User $user): bool
+    {
+        return $user->isActive();
+    }
+
+}


### PR DESCRIPTION
## Summary

Closes #98

- Add test for boolean helper methods on model instances (the exact use case from the issue: `$user->isActive()`, `$account->hasCreditPlan()` etc.) — these must **not** trigger PHPStan errors
- Add test verifying bare retrieval-only calls (`User::query()->get()`) pass the `NoDirectDatabaseQueriesInActionsRule` check (errors from other rules are filtered out by message)
- Add `ActionWithBooleanHelperMethod` fixture to cover the real-world scenario
- Add `isActive(): bool` helper to the test `User` model
- Refactor `processNode()` to fix PHPCS cognitive complexity (9→8) by extracting `isApplicableContext()`
- Simplify `isPotentialScope()` to compact return form — reduces class length below PHPCS 250-line threshold

## Test plan

- [ ] `composer fix` passes with no changes
- [ ] `composer phpcs-check` passes (class length and complexity within limits)
- [ ] `vendor/bin/pest tests/PHPStan/Rules/NoDirectDatabaseQueriesInActionsRuleTest.php` — 5 tests pass
- [ ] All existing PHPStan rule tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)