### PR TITLE
feat(deps): allow illuminate/* v13 and testbench v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
     "php": "^8.4",
     "ext-simplexml": "*",
     "baopham/dynamodb": "^7.0",
-    "illuminate/contracts": "^12.0",
-    "illuminate/database": "^12.0",
-    "illuminate/pagination": "^12.0",
-    "illuminate/support": "^12.0",
+    "illuminate/contracts": "^12.0 || ^13.0",
+    "illuminate/database": "^12.0 || ^13.0",
+    "illuminate/pagination": "^12.0 || ^13.0",
+    "illuminate/support": "^12.0 || ^13.0",
     "spatie/laravel-data": "^4.20.1"
   },
   "require-dev": {
@@ -42,7 +42,7 @@
     "iksaku/laravel-mass-update": "^1.0.8",
     "larastan/larastan": "^3.9.3",
     "laravel/pint": "^1.29.0",
-    "orchestra/testbench": "^10.11",
+    "orchestra/testbench": "^10.11 || ^11.0",
     "pekral/cursor-rules": "dev-master",
     "pekral/phpcs-rules": "^0.4.8",
     "pekral/rector-rules": "^0.4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52e6f21767f9ad238174497173819e73",
+    "content-hash": "d6f7bcf3d8af074ff1be793423255cbc",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
## Summary
- Bumped `illuminate/contracts`, `illuminate/database`, `illuminate/pagination`, `illuminate/support` from `^12.0` to `^12.0 || ^13.0`
- Bumped `orchestra/testbench` from `^10.11` to `^10.11 || ^11.0` for Laravel 13 test compatibility
- `larastan/larastan ^3.9.3` already supports Laravel 13 — no change needed

## Related
Closes https://github.com/pekral/arch-app-services/issues/103

## Test plan
- [ ] Verify `composer validate` passes
- [ ] Verify PHPStan analysis passes (`composer analyse`)
- [ ] Verify all existing tests pass (`vendor/bin/pest`)
- [ ] Test installation in a Laravel 13 project to confirm dependency resolution works