### PR TITLE
feat(phpstan): NoWhereRawRule — forbid whereRaw() and orWhereRaw()

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -67,3 +67,7 @@ services:
         class: Pekral\Arch\PHPStan\Rules\ActionReturnDtoRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\NoWhereRawRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.test.neon
+++ b/phpstan.test.neon
@@ -33,3 +33,7 @@ services:
         class: Pekral\Arch\PHPStan\Rules\ActionReturnDtoRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\NoWhereRawRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan/Rules/NoWhereRawRule.php
+++ b/phpstan/Rules/NoWhereRawRule.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Forbids whereRaw() and orWhereRaw() calls on Eloquent models and query builders.
+ * Raw where clauses bypass parameter binding and pose a SQL injection risk.
+ *
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr>
+ */
+final class NoWhereRawRule implements Rule
+{
+
+    private const array FORBIDDEN_METHODS = [
+        'whereRaw',
+        'orWhereRaw',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node\Expr::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr $node
+     * @return array<int, \PHPStan\Rules\RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof MethodCall && !$node instanceof StaticCall) {
+            return [];
+        }
+
+        $methodName = $this->getMethodName($node);
+
+        if ($methodName === null || !$this->isForbiddenMethod($methodName)) {
+            return [];
+        }
+
+        $callerType = $this->getCallerType($node, $scope);
+
+        if ($callerType === null || !$this->isEloquentModelOrBuilder($callerType)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Method "%s()" is forbidden. Raw where clauses bypass parameter binding '
+                    . 'and pose a SQL injection risk. Use Eloquent query builder methods instead.',
+                    $methodName,
+                ),
+            )->build(),
+        ];
+    }
+
+    private function getMethodName(MethodCall|StaticCall $node): ?string
+    {
+        if (!$node->name instanceof Node\Identifier) {
+            return null;
+        }
+
+        return $node->name->toString();
+    }
+
+    private function isForbiddenMethod(string $methodName): bool
+    {
+        return in_array($methodName, self::FORBIDDEN_METHODS, true);
+    }
+
+    private function getCallerType(MethodCall|StaticCall $node, Scope $scope): ?Type
+    {
+        if ($node instanceof MethodCall) {
+            return $scope->getType($node->var);
+        }
+
+        if ($node->class instanceof Node\Name) {
+            return $scope->resolveTypeByName($node->class);
+        }
+
+        return null;
+    }
+
+    private function isEloquentModelOrBuilder(Type $type): bool
+    {
+        $eloquentModelType = new ObjectType('Illuminate\Database\Eloquent\Model');
+        $queryBuilderType = new ObjectType('Illuminate\Database\Eloquent\Builder');
+        $baseBuilderType = new ObjectType('Illuminate\Database\Query\Builder');
+
+        return $eloquentModelType->isSuperTypeOf($type)->yes()
+            || $queryBuilderType->isSuperTypeOf($type)->yes()
+            || $baseBuilderType->isSuperTypeOf($type)->yes();
+    }
+
+}

--- a/tests/PHPStan/Rules/NoWhereRawRuleTest.php
+++ b/tests/PHPStan/Rules/NoWhereRawRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+use Pekral\Arch\Tests\PHPStan\Helpers\PhpstanFixtureRunner;
+
+test('NoWhereRawRule blocks whereRaw calls on Eloquent query builder', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoWhereRawRule',
+    );
+
+    expect($errors)->toHaveKey('ClassWithWhereRaw.php');
+
+    $forbiddenErrors = $errors['ClassWithWhereRaw.php'];
+    $whereRawMessage = 'Method "whereRaw()" is forbidden. Raw where clauses bypass parameter binding '
+        . 'and pose a SQL injection risk. Use Eloquent query builder methods instead.';
+    $orWhereRawMessage = 'Method "orWhereRaw()" is forbidden. Raw where clauses bypass parameter binding '
+        . 'and pose a SQL injection risk. Use Eloquent query builder methods instead.';
+
+    expect($forbiddenErrors)
+        ->toContain($whereRawMessage)
+        ->toContain($orWhereRawMessage);
+});
+
+test('NoWhereRawRule allows safe Eloquent query builder methods', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoWhereRawRule',
+    );
+
+    $safeErrors = array_filter(
+        $errors['ClassWithSafeQueries.php'] ?? [],
+        static fn (string $msg): bool => str_contains($msg, 'whereRaw') || str_contains($msg, 'orWhereRaw'),
+    );
+
+    expect($safeErrors)->toBeEmpty();
+});
+
+test('NoWhereRawRule blocks whereRaw in Action classes', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/NoWhereRawRule',
+    );
+
+    expect($errors)->toHaveKey('ActionWithWhereRaw.php');
+
+    $actionErrors = array_filter(
+        $errors['ActionWithWhereRaw.php'],
+        static fn (string $msg): bool => str_contains($msg, 'whereRaw'),
+    );
+
+    expect($actionErrors)->not->toBeEmpty();
+});

--- a/tests/fixtures/PHPStan/NoWhereRawRule/ActionWithWhereRaw.php
+++ b/tests/fixtures/PHPStan/NoWhereRawRule/ActionWithWhereRaw.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoWhereRawRule;
+
+use Pekral\Arch\Action\ArchAction;
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Action that uses whereRaw — must trigger errors from this rule.
+ */
+final readonly class ActionWithWhereRaw implements ArchAction
+{
+
+    public function __invoke(): void
+    {
+        User::query()->whereRaw('email LIKE ?', ['%test%'])->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/NoWhereRawRule/ClassWithSafeQueries.php
+++ b/tests/fixtures/PHPStan/NoWhereRawRule/ClassWithSafeQueries.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoWhereRawRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Class that uses safe Eloquent query builder methods — must NOT trigger errors.
+ */
+final class ClassWithSafeQueries
+{
+
+    public function usingSafeWhere(): void
+    {
+        User::query()->where('email', 'test@example.com')->get();
+    }
+
+    public function usingSafeWhereIn(): void
+    {
+        User::query()->whereIn('id', [1, 2, 3])->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/NoWhereRawRule/ClassWithWhereRaw.php
+++ b/tests/fixtures/PHPStan/NoWhereRawRule/ClassWithWhereRaw.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\NoWhereRawRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Class that uses forbidden whereRaw/orWhereRaw methods — must trigger errors.
+ */
+final class ClassWithWhereRaw
+{
+
+    public function usingWhereRaw(): void
+    {
+        User::query()->whereRaw('email = ?', ['test@example.com'])->get();
+    }
+
+    public function usingOrWhereRaw(): void
+    {
+        User::query()->orWhereRaw('name = ?', ['test'])->get();
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds new PHPStan rule `NoWhereRawRule` that forbids `whereRaw()` and `orWhereRaw()` calls on Eloquent models and query builders
- Raw where clauses bypass parameter binding and pose a SQL injection risk
- Rule applies globally (not just in Action classes) since raw SQL is a security concern everywhere

Closes #104

## Changes

- `phpstan/Rules/NoWhereRawRule.php` — new PHPStan rule implementation
- `phpstan.neon` / `phpstan.test.neon` — rule registration
- `tests/PHPStan/Rules/NoWhereRawRuleTest.php` — 3 test cases (6 assertions)
- `tests/fixtures/PHPStan/NoWhereRawRule/` — test fixtures (forbidden + safe + action)

## Sources

- https://github.com/pekral/arch-app-services/issues/104

## Testing Recommendations

- Verify that `whereRaw()` and `orWhereRaw()` calls trigger PHPStan errors in any class
- Verify that safe Eloquent methods (`where()`, `whereIn()`, etc.) are not affected
- Run `composer analyse` to confirm no false positives in the existing codebase