### PR TITLE
feat(phpstan): WhereRawBindingsRule — enforce bindings for dynamic whereRaw expressions

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -67,3 +67,7 @@ services:
         class: Pekral\Arch\PHPStan\Rules\ActionReturnDtoRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\WhereRawBindingsRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan.test.neon
+++ b/phpstan.test.neon
@@ -33,3 +33,7 @@ services:
         class: Pekral\Arch\PHPStan\Rules\ActionReturnDtoRule
         tags:
             - phpstan.rules.rule
+    -
+        class: Pekral\Arch\PHPStan\Rules\WhereRawBindingsRule
+        tags:
+            - phpstan.rules.rule

--- a/phpstan/Rules/WhereRawBindingsRule.php
+++ b/phpstan/Rules/WhereRawBindingsRule.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Ensures whereRaw() calls with dynamic SQL expressions always provide bindings to prevent SQL injection.
+ *
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr>
+ */
+final class WhereRawBindingsRule implements Rule
+{
+
+    private const array RAW_METHODS = [
+        'whereRaw',
+        'orWhereRaw',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node\Expr::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr $node
+     * @return array<int, \PHPStan\Rules\RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof MethodCall && !$node instanceof StaticCall) {
+            return [];
+        }
+
+        $methodName = $this->getMethodName($node);
+
+        if ($methodName === null || !$this->isRawMethod($methodName)) {
+            return [];
+        }
+
+        $callerType = $this->getCallerType($node, $scope);
+
+        if ($callerType === null || !$this->isQueryBuilderOrModel($callerType)) {
+            return [];
+        }
+
+        if ($this->hasBindingsArgument($node)) {
+            return [];
+        }
+
+        if ($this->isStaticStringLiteral($node)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Call to %s() with a dynamic expression requires bindings (second argument) to prevent SQL injection.',
+                    $methodName,
+                ),
+            )->build(),
+        ];
+    }
+
+    private function getMethodName(Node $node): ?string
+    {
+        if (!$node instanceof MethodCall && !$node instanceof StaticCall) {
+            return null;
+        }
+
+        if (!$node->name instanceof Node\Identifier) {
+            return null;
+        }
+
+        return $node->name->toString();
+    }
+
+    private function isRawMethod(string $methodName): bool
+    {
+        return in_array($methodName, self::RAW_METHODS, true);
+    }
+
+    private function getCallerType(Node $node, Scope $scope): ?Type
+    {
+        if ($node instanceof MethodCall) {
+            return $scope->getType($node->var);
+        }
+
+        if ($node instanceof StaticCall && $node->class instanceof Node\Name) {
+            return $scope->resolveTypeByName($node->class);
+        }
+
+        return null;
+    }
+
+    private function isQueryBuilderOrModel(Type $type): bool
+    {
+        $eloquentModelType = new ObjectType('Illuminate\Database\Eloquent\Model');
+        $eloquentBuilderType = new ObjectType('Illuminate\Database\Eloquent\Builder');
+        $queryBuilderType = new ObjectType('Illuminate\Database\Query\Builder');
+
+        return $eloquentModelType->isSuperTypeOf($type)->yes()
+            || $eloquentBuilderType->isSuperTypeOf($type)->yes()
+            || $queryBuilderType->isSuperTypeOf($type)->yes();
+    }
+
+    /**
+     * Checks whether the call has a second argument (bindings array).
+     */
+    private function hasBindingsArgument(MethodCall|StaticCall $node): bool
+    {
+        return count($node->getArgs()) >= 2;
+    }
+
+    /**
+     * Returns true when the first argument is a plain string literal without interpolation or concatenation.
+     */
+    private function isStaticStringLiteral(MethodCall|StaticCall $node): bool
+    {
+        $args = $node->getArgs();
+
+        if ($args === []) {
+            return false;
+        }
+
+        return $args[0]->value instanceof String_;
+    }
+
+}

--- a/tests/PHPStan/Rules/WhereRawBindingsRuleTest.php
+++ b/tests/PHPStan/Rules/WhereRawBindingsRuleTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+use Pekral\Arch\Tests\PHPStan\Helpers\PhpstanFixtureRunner;
+
+test('WhereRawBindingsRule allows static string literals without bindings', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/WhereRawBindingsRule',
+    );
+
+    $ruleErrors = array_filter(
+        $errors['WhereRawWithStaticString.php'] ?? [],
+        static fn (string $msg): bool => str_contains($msg, 'requires bindings'),
+    );
+
+    expect($ruleErrors)->toBeEmpty();
+});
+
+test('WhereRawBindingsRule allows dynamic expressions with bindings', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/WhereRawBindingsRule',
+    );
+
+    $ruleErrors = array_filter(
+        $errors['WhereRawWithBindings.php'] ?? [],
+        static fn (string $msg): bool => str_contains($msg, 'requires bindings'),
+    );
+
+    expect($ruleErrors)->toBeEmpty();
+});
+
+test('WhereRawBindingsRule flags string concatenation without bindings', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/WhereRawBindingsRule',
+    );
+
+    expect($errors)->toHaveKey('WhereRawWithConcatenation.php');
+
+    $ruleErrors = $errors['WhereRawWithConcatenation.php'];
+    expect($ruleErrors)->toContain(
+        'Call to whereRaw() with a dynamic expression requires bindings (second argument) to prevent SQL injection.',
+    );
+});
+
+test('WhereRawBindingsRule flags interpolated strings without bindings', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/WhereRawBindingsRule',
+    );
+
+    expect($errors)->toHaveKey('WhereRawWithInterpolation.php');
+
+    $ruleErrors = $errors['WhereRawWithInterpolation.php'];
+    expect($ruleErrors)->toContain(
+        'Call to whereRaw() with a dynamic expression requires bindings (second argument) to prevent SQL injection.',
+    );
+});
+
+test('WhereRawBindingsRule flags variable arguments without bindings', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/WhereRawBindingsRule',
+    );
+
+    expect($errors)->toHaveKey('WhereRawWithVariable.php');
+
+    $ruleErrors = $errors['WhereRawWithVariable.php'];
+    expect($ruleErrors)
+        ->toContain('Call to whereRaw() with a dynamic expression requires bindings (second argument) to prevent SQL injection.')
+        ->toContain('Call to orWhereRaw() with a dynamic expression requires bindings (second argument) to prevent SQL injection.');
+});
+
+test('WhereRawBindingsRule flags function call results without bindings', function (): void {
+    $errors = PhpstanFixtureRunner::run(
+        __DIR__ . '/../../../tests/fixtures/PHPStan/WhereRawBindingsRule',
+    );
+
+    expect($errors)->toHaveKey('WhereRawWithFunctionCall.php');
+
+    $ruleErrors = $errors['WhereRawWithFunctionCall.php'];
+    expect($ruleErrors)->toContain(
+        'Call to whereRaw() with a dynamic expression requires bindings (second argument) to prevent SQL injection.',
+    );
+});

--- a/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithBindings.php
+++ b/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithBindings.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\WhereRawBindingsRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Dynamic expressions with bindings — allowed.
+ */
+final class WhereRawWithBindings
+{
+
+    public function handle(int $price, string $status): void
+    {
+        User::query()->whereRaw('price > ?', [$price])->get();
+        User::query()->orWhereRaw('status = ?', [$status])->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithConcatenation.php
+++ b/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithConcatenation.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\WhereRawBindingsRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * String concatenation in whereRaw without bindings — must trigger error.
+ */
+final class WhereRawWithConcatenation
+{
+
+    public function handle(string $column): void
+    {
+        User::query()->whereRaw('price > ' . $column)->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithFunctionCall.php
+++ b/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithFunctionCall.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\WhereRawBindingsRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Function call result as whereRaw argument without bindings — must trigger error.
+ */
+final class WhereRawWithFunctionCall
+{
+
+    public function handle(): void
+    {
+        User::query()->whereRaw($this->buildCondition())->get();
+    }
+
+    private function buildCondition(): string
+    {
+        return 'price > 100';
+    }
+
+}

--- a/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithInterpolation.php
+++ b/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithInterpolation.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\WhereRawBindingsRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Interpolated strings in whereRaw without bindings — must trigger error.
+ */
+final class WhereRawWithInterpolation
+{
+
+    public function handle(string $column): void
+    {
+        User::query()->whereRaw("price > {$column}")->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithStaticString.php
+++ b/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithStaticString.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\WhereRawBindingsRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Static string literals in whereRaw — allowed without bindings.
+ */
+final class WhereRawWithStaticString
+{
+
+    public function handle(): void
+    {
+        User::query()->whereRaw('status = 1')->get();
+        User::query()->orWhereRaw('deleted_at IS NULL')->get();
+    }
+
+}

--- a/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithVariable.php
+++ b/tests/fixtures/PHPStan/WhereRawBindingsRule/WhereRawWithVariable.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\Arch\Tests\Fixtures\PHPStan\WhereRawBindingsRule;
+
+use Pekral\Arch\Tests\Models\User;
+
+/**
+ * Variable as whereRaw argument without bindings — must trigger error.
+ */
+final class WhereRawWithVariable
+{
+
+    public function handle(string $condition): void
+    {
+        User::query()->whereRaw($condition)->get();
+        User::query()->orWhereRaw($condition)->get();
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds `WhereRawBindingsRule` PHPStan rule that flags `whereRaw()` and `orWhereRaw()` calls using dynamic SQL expressions (variables, concatenation, interpolation, function calls) without a bindings parameter
- Static string literals (e.g. `whereRaw('status = 1')`) are allowed without bindings
- Prevents SQL injection by enforcing parameterized queries in raw WHERE clauses

## Test plan
- [x] 6 fixture-based tests covering all scenarios (static strings, bindings, concatenation, interpolation, variables, function calls)
- [x] PHPStan analysis passes at max level
- [x] All existing tests continue to pass

Closes #104

🤖 Generated with [Claude Code](https://claude.ai/claude-code)