### PR TITLE
fix(repository): make BaseRepository readonly class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ final readonly class CreateUser implements ArchAction
 
 ### Repository with Caching
 ```php
-final class UserRepository extends BaseRepository
+final readonly class UserRepository extends BaseRepository
 {
     use CacheableRepository;
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ use App\Models\User;
 /**
  * @extends \Pekral\Arch\Repository\Mysql\BaseRepository<\App\Models\User>
  */
-final class UserRepository extends BaseRepository
+final readonly class UserRepository extends BaseRepository
 {
     use CacheableRepository;
 
@@ -131,7 +131,7 @@ namespace App\Repositories;
 use Pekral\Arch\Repository\Mysql\BaseRepository;
 use App\Models\User;
 
-final class UserRepository extends BaseRepository
+final readonly class UserRepository extends BaseRepository
 {
     protected function getModelClassName(): string
     {

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -137,7 +137,7 @@ use App\Models\User;
 /**
  * @extends BaseRepository<User>
  */
-final class UserRepository extends BaseRepository
+final readonly class UserRepository extends BaseRepository
 {
 
     protected function getModelClassName(): string

--- a/docs/query-builder-methods.md
+++ b/docs/query-builder-methods.md
@@ -51,7 +51,7 @@ Thanks to generic types (`@template`) in `BaseRepository` and correctly written 
 /**
  * @extends \Pekral\Arch\Repository\Mysql\BaseRepository<\App\Models\Job>
  */
-final class JobRepository extends BaseRepository
+final readonly class JobRepository extends BaseRepository
 {
     protected function getModelClassName(): string
     {

--- a/docs/repository-caching.md
+++ b/docs/repository-caching.md
@@ -5,7 +5,7 @@ Repositories can opt in to transparent read caching by using the `Pekral\Arch\Re
 ## Enabling caching for a repository
 
 ```php
-final class UserRepository extends BaseRepository
+final readonly class UserRepository extends BaseRepository
 {
     use CacheableRepository;
 

--- a/examples/Services/User/UserDynamoRepository.php
+++ b/examples/Services/User/UserDynamoRepository.php
@@ -10,7 +10,7 @@ use Pekral\Arch\Tests\Models\UserDynamoModel;
 /**
  * @extends \Pekral\Arch\Repository\DynamoDb\BaseRepository<\Pekral\Arch\Tests\Models\UserDynamoModel>
  */
-final class UserDynamoRepository extends BaseRepository
+final readonly class UserDynamoRepository extends BaseRepository
 {
 
     protected function getModelClassName(): string

--- a/examples/Services/User/UserRepository.php
+++ b/examples/Services/User/UserRepository.php
@@ -11,7 +11,7 @@ use Pekral\Arch\Tests\Models\User;
 /**
  * @extends \Pekral\Arch\Repository\Mysql\BaseRepository<\Pekral\Arch\Tests\Models\User>
  */
-final class UserRepository extends BaseRepository
+final readonly class UserRepository extends BaseRepository
 {
 
     use CacheableRepository;

--- a/src/Repository/DynamoDb/BaseRepository.php
+++ b/src/Repository/DynamoDb/BaseRepository.php
@@ -20,7 +20,7 @@ use function is_array;
  * @template TModel of \BaoPham\DynamoDb\DynamoDbModel
  * @implements \Pekral\Arch\Repository\Repository<TModel>
  */
-abstract class BaseRepository implements Repository
+abstract readonly class BaseRepository implements Repository
 {
 
     /**

--- a/src/Repository/Mysql/BaseRepository.php
+++ b/src/Repository/Mysql/BaseRepository.php
@@ -19,7 +19,7 @@ use function is_array;
  * @implements \Pekral\Arch\Repository\Repository<TModel>
  * @method \Pekral\Arch\Repository\CacheWrapper cache()
  */
-abstract class BaseRepository implements Repository
+abstract readonly class BaseRepository implements Repository
 {
 
     /**

--- a/src/stubs/repository.stub
+++ b/src/stubs/repository.stub
@@ -11,7 +11,7 @@ use {{ modelClass }};
 /**
  * @extends \Pekral\Arch\Repository\Mysql\BaseRepository<\{{ modelClass }}>
  */
-final class {{ class }} extends BaseRepository
+final readonly class {{ class }} extends BaseRepository
 {
 
     use CacheableRepository;

--- a/tests/Unit/Console/Commands/MakeArchServiceCommandTest.php
+++ b/tests/Unit/Console/Commands/MakeArchServiceCommandTest.php
@@ -37,7 +37,7 @@ final class MakeArchServiceCommandTest extends TestCase
 
         $repositoryContent = file_get_contents($repositoryPath);
         $this->assertStringContainsString('namespace App\Services\Product;', $repositoryContent);
-        $this->assertStringContainsString('final class ProductRepository extends BaseRepository', $repositoryContent);
+        $this->assertStringContainsString('final readonly class ProductRepository extends BaseRepository', $repositoryContent);
         $this->assertStringContainsString('use CacheableRepository;', $repositoryContent);
 
         $serviceContent = file_get_contents($servicePath);

--- a/tests/Unit/Repository/CacheableRepositoryTest.php
+++ b/tests/Unit/Repository/CacheableRepositoryTest.php
@@ -378,7 +378,7 @@ test('cache wrapper uses default driver when no driver specified', function (): 
 /**
  * @extends \Pekral\Arch\Repository\Mysql\BaseRepository<\Pekral\Arch\Tests\Models\User>
  */
-final class TestCacheableUserRepository extends BaseRepository
+final readonly class TestCacheableUserRepository extends BaseRepository
 {
 
     use CacheableRepository;

--- a/tests/Unit/Transaction/CacheWrapperTransactionTest.php
+++ b/tests/Unit/Transaction/CacheWrapperTransactionTest.php
@@ -199,7 +199,7 @@ test('clear all cache does not execute when transaction is rolled back', functio
 /**
  * @extends \Pekral\Arch\Repository\Mysql\BaseRepository<\Pekral\Arch\Tests\Models\User>
  */
-final class CacheWrapperTransactionRepository extends BaseRepository
+final readonly class CacheWrapperTransactionRepository extends BaseRepository
 {
 
     use CacheableRepository;

--- a/tests/fixtures/PHPStan/OnlyRepositoriesCanQueryDataRule/ValidModelService.php
+++ b/tests/fixtures/PHPStan/OnlyRepositoriesCanQueryDataRule/ValidModelService.php
@@ -47,7 +47,7 @@ final readonly class ValidModelService extends BaseModelService
 /**
  * @extends BaseRepository<User>
  */
-final class ValidServiceRepository extends BaseRepository
+final readonly class ValidServiceRepository extends BaseRepository
 {
 
     protected function getModelClassName(): string

--- a/tests/fixtures/PHPStan/OnlyRepositoriesCanQueryDataRule/ValidRepository.php
+++ b/tests/fixtures/PHPStan/OnlyRepositoriesCanQueryDataRule/ValidRepository.php
@@ -10,7 +10,7 @@ use Pekral\Arch\Tests\Models\User;
 /**
  * @extends BaseRepository<User>
  */
-final class ValidRepository extends BaseRepository
+final readonly class ValidRepository extends BaseRepository
 {
 
     protected function getModelClassName(): string


### PR DESCRIPTION
## Summary
- Both MySQL and DynamoDB `BaseRepository` classes are now `abstract readonly`, enforcing immutability at the type level
- All extending repository classes updated to `final readonly`
- Repository stub template updated for generated code consistency
- Documentation and test assertions updated accordingly

Closes #110

## Test plan
- [x] All existing tests pass with 100% code coverage
- [x] PHPStan static analysis passes at max level
- [x] Code style checks (Pint, PHPCS, Rector) pass
- [x] Security audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)